### PR TITLE
Fix missing Query import

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -1,5 +1,5 @@
 ﻿# main.py - Servidor principal FastAPI
-from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 from typing import List


### PR DESCRIPTION
## Summary
- fix `NameError` in `get_audit_logs` by importing `Query` from FastAPI

## Testing
- `python3 -m py_compile ShippingServer/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68764d247ca48331b58cf11c45f5fbf0