### PR TITLE
Fix status column mapping and label typo

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -377,7 +377,7 @@ class ModernShippingMainWindow(QMainWindow):
         """Configurar tabla con estilo profesional"""
         columns = [
             "Job Number", "Job Name", "Description",
-            "Status", "QC Release", "Created", "Ship Plan", "Shipped",
+            "Status", "QC Release", "Crated", "Ship Plan", "Shipped",
             "Invoice Number", "Notes"
         ]
         
@@ -442,7 +442,7 @@ class ModernShippingMainWindow(QMainWindow):
         header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)  # Job Number
         header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)  # Job Name
         header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)  # Shipping List
-        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)  # Status
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)  # Status
         
         # Eventos
         table.selectionModel().selectionChanged.connect(self.on_selection_changed)
@@ -664,14 +664,14 @@ class ModernShippingMainWindow(QMainWindow):
             item = QTableWidgetItem(str(item_text))
             
             # Aplicar estilos profesionales
-            if col == 5:  # Columna status
+            if col == 3:  # Columna status
                 self.style_professional_status_item(item, shipment.get("status", ""))
             elif not is_active and col == 9 and item_text:  # Shipped en history
                 item.setFont(QFont("Segoe UI", 11, QFont.Weight.Medium))
                 item.setForeground(QColor("#059669"))
             
             # Alineación
-            if col in [0, 10]:  # Job # e Invoice #
+            if col in [0, 8]:  # Job # e Invoice #
                 item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             
             table.setItem(row, col, item)

--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -222,12 +222,12 @@ class ModernShipmentDialog(QDialog):
         dates_grid.setSpacing(15)
         dates_grid.setContentsMargins(0, 10, 0, 0)
         
-        # Fila 1: QC Release y Created
+        # Fila 1: QC Release y Crated
         dates_grid.addWidget(self.create_field_label("QC Release"), 0, 0)
         self.qc_release_edit = ModernLineEdit("MM/DD/YY")
         dates_grid.addWidget(self.qc_release_edit, 0, 1)
-        
-        dates_grid.addWidget(self.create_field_label("Created"), 0, 2)
+
+        dates_grid.addWidget(self.create_field_label("Crated"), 0, 2)
         self.created_edit = ModernLineEdit("MM/DD/YY")
         dates_grid.addWidget(self.created_edit, 0, 3)
         


### PR DESCRIPTION
## Summary
- rename table column label to **Crated**
- fix incorrect column index for Status
- adjust column alignment and resize logic
- update shipment dialog label to **Crated**

## Testing
- `python3 -m py_compile ShippingClient/ui/main_window.py ShippingClient/ui/shipment_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_687659a0a6148331a635c8c6230ae88e