### PR TITLE
Fix stylesheet braces in shipment dialog

### DIFF
--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -315,13 +315,13 @@ class ModernShipmentDialog(QDialog):
                 color: #1F2937;
                 selection-background-color: #DBEAFE;
             }}
-            QTextEdit:focus {
+            QTextEdit:focus {{
                 border-color: #3B82F6;
                 outline: none;
-            }
-            QTextEdit:hover {
+            }}
+            QTextEdit:hover {{
                 border-color: #9CA3AF;
-            }
+            }}
         """)
         return text_edit
     


### PR DESCRIPTION
## Summary
- escape CSS braces in `create_professional_text_edit` to avoid `NameError`

## Testing
- `python3 -m py_compile ShippingClient/ui/shipment_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_687666e260448331b7898b110146dfd7