### PR TITLE
Fix stylesheet string in shipment dialog

### DIFF
--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -367,9 +367,9 @@ class ModernShipmentDialog(QDialog):
                 background: #F3F4F6;
                 font-family: '{MODERN_FONT}', sans-serif;
             }}
-            QLabel {
+            QLabel {{
                 color: #374151;
-            }
+            }}
         """)
     
     def populate_form(self, data):


### PR DESCRIPTION
## Summary
- escape CSS braces in `apply_professional_theme`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68766bbfb9e88331848e3fea5e863c36