### PR TITLE
Fix styling error in shipment dialog

### DIFF
--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -501,12 +501,12 @@ class ModernShipmentDialog(QDialog):
                 background: #FFFFFF;
                 font-family: '{MODERN_FONT}';
             }}
-            QMessageBox QLabel {
+            QMessageBox QLabel {{
                 color: #374151;
                 font-size: 13px;
                 padding: 10px;
-            }
-            QMessageBox QPushButton {
+            }}
+            QMessageBox QPushButton {{
                 background: #3B82F6;
                 color: white;
                 border: none;
@@ -515,10 +515,10 @@ class ModernShipmentDialog(QDialog):
                 font-weight: 500;
                 font-size: 12px;
                 min-width: 80px;
-            }
-            QMessageBox QPushButton:hover {
+            }}
+            QMessageBox QPushButton:hover {{
                 background: #2563EB;
-            }
+            }}
         """)
         
         msg.exec()


### PR DESCRIPTION
## Summary
- escape CSS braces in `show_professional_error` to avoid NameError

## Testing
- `python -m py_compile ShippingClient/ui/shipment_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_68767ff2d2088331a66517ab36dff6b0