### PR TITLE
Fix WebSocket disconnect handling

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -35,15 +35,16 @@ class ConnectionManager:
         self.active_connections.append(websocket)
 
     def disconnect(self, websocket: WebSocket):
-        self.active_connections.remove(websocket)
+        if websocket in self.active_connections:
+            self.active_connections.remove(websocket)
 
     async def broadcast(self, message: str):
-        for connection in self.active_connections:
+        for connection in self.active_connections.copy():
             try:
                 await connection.send_text(message)
             except:
                 # Conexión cerrada, remover
-                self.active_connections.remove(connection)
+                self.disconnect(connection)
 
 manager = ConnectionManager()
 


### PR DESCRIPTION
## Summary
- ensure disconnect checks if websocket is registered before removal
- use a copy of the connection list when broadcasting messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877b2e5ea3c8331a3a5dc9e25495725