### PR TITLE
Fix crash when saving shipment without job number

### DIFF
--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -411,6 +411,9 @@ class ModernShipmentDialog(QDialog):
     def save_shipment(self):
         """Guardar shipment con validaciones"""
         try:
+            # Guardar el texto original del botón por si se necesita restaurar
+            original_text = self.save_btn.text()
+
             # Validaciones
             if not self.job_number_edit.text().strip():
                 self.show_professional_error("Job Number is required")
@@ -446,9 +449,8 @@ class ModernShipmentDialog(QDialog):
             }
             
             print(f"Guardando shipment: {data['job_number']}")
-            
+
             # Cambiar estado del botón
-            original_text = self.save_btn.text()
             self.save_btn.setText("Saving...")
             self.save_btn.setEnabled(False)
             


### PR DESCRIPTION
## Summary
- fix `ModernShipmentDialog.save_shipment` crash when validation fails

## Testing
- `python -m py_compile ShippingClient/ui/shipment_dialog.py`
- `python -m py_compile ShippingClient/migrate_excel.py ShippingClient/main_client.py ShippingClient/core/websocket_client.py ShippingClient/core/settings_manager.py ShippingClient/core/config.py ShippingClient/__init__.py ShippingClient/ui/settings_dialog.py ShippingClient/ui/widgets.py ShippingClient/ui/shipment_dialog.py ShippingClient/ui/user_dialog.py ShippingClient/ui/login_dialog.py ShippingClient/ui/utils.py ShippingClient/ui/main_window.py ShippingServer/main.py ShippingServer/database.py ShippingServer/models.py ShippingServer/utils.py ShippingServer/auth.py`

------
https://chatgpt.com/codex/tasks/task_e_6877e341d0f08331838e8811470d99c7