### PR TITLE
Add QC Notes field

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -430,7 +430,7 @@ class ModernShippingMainWindow(QMainWindow):
         """Configurar tabla con estilo profesional y restaurar ancho de columnas"""
         columns = [
             "Job Number", "Job Name", "Description",
-            "Status", "QC Release", "Crated", "Ship Plan", "Shipped",
+            "Status", "QC Release", "QC Notes", "Crated", "Ship Plan", "Shipped",
             "Invoice Number", "Notes"
         ]
         
@@ -745,6 +745,7 @@ class ModernShippingMainWindow(QMainWindow):
             self.truncate_text(shipment.get("description", ""), 45),
             shipment.get("status", ""),
             shipment.get("qc_release", ""),
+            shipment.get("qc_notes", ""),
             shipment.get("created", ""),
             shipment.get("ship_plan", ""),
             shipment.get("shipped", ""),
@@ -758,12 +759,12 @@ class ModernShippingMainWindow(QMainWindow):
             # Aplicar estilos profesionales
             if col == 3:  # Columna status
                 self.style_professional_status_item(item, shipment.get("status", ""))
-            elif not is_active and col == 9 and item_text:  # Shipped en history
+            elif not is_active and col == 8 and item_text:  # Shipped en history
                 item.setFont(QFont(MODERN_FONT, 11, QFont.Weight.Medium))
                 item.setForeground(QColor("#059669"))
             
             # Alineación
-            if col in [0, 8]:  # Job # e Invoice #
+            if col in [0, 9]:  # Job # e Invoice #
                 item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             
             table.setItem(row, col, item)

--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -237,23 +237,28 @@ class ModernShipmentDialog(QDialog):
         dates_grid.setSpacing(15)
         dates_grid.setContentsMargins(0, 10, 0, 0)
         
-        # Fila 1: QC Release y Crated
+        # Fila 1: QC Release y QC Notes
         dates_grid.addWidget(self.create_field_label("QC Release"), 0, 0)
         self.qc_release_edit = ModernLineEdit("MM/DD/YY")
         dates_grid.addWidget(self.qc_release_edit, 0, 1)
 
-        dates_grid.addWidget(self.create_field_label("Crated"), 0, 2)
+        dates_grid.addWidget(self.create_field_label("QC Notes"), 0, 2)
+        self.qc_notes_edit = ModernLineEdit()
+        dates_grid.addWidget(self.qc_notes_edit, 0, 3)
+
+        # Fila 2: Crated y Ship Plan
+        dates_grid.addWidget(self.create_field_label("Crated"), 1, 0)
         self.created_edit = ModernLineEdit("MM/DD/YY")
-        dates_grid.addWidget(self.created_edit, 0, 3)
-        
-        # Fila 2: Ship Plan y Shipped
-        dates_grid.addWidget(self.create_field_label("Ship Plan"), 1, 0)
+        dates_grid.addWidget(self.created_edit, 1, 1)
+
+        dates_grid.addWidget(self.create_field_label("Ship Plan"), 1, 2)
         self.ship_plan_edit = ModernLineEdit("MM/DD/YY")
-        dates_grid.addWidget(self.ship_plan_edit, 1, 1)
-        
-        dates_grid.addWidget(self.create_field_label("Shipped"), 1, 2)
+        dates_grid.addWidget(self.ship_plan_edit, 1, 3)
+
+        # Fila 3: Shipped
+        dates_grid.addWidget(self.create_field_label("Shipped"), 2, 0)
         self.shipped_edit = ModernLineEdit("MM/DD/YY")
-        dates_grid.addWidget(self.shipped_edit, 1, 3)
+        dates_grid.addWidget(self.shipped_edit, 2, 1)
         
         dates_card.add_layout(dates_grid)
         layout.addWidget(dates_card)
@@ -398,6 +403,7 @@ class ModernShipmentDialog(QDialog):
                 self.status_combo.setCurrentIndex(index)
             
             self.qc_release_edit.setText(safe_str(data.get("qc_release")))
+            self.qc_notes_edit.setText(safe_str(data.get("qc_notes")))
             self.created_edit.setText(safe_str(data.get("created")))
             self.ship_plan_edit.setText(safe_str(data.get("ship_plan")))
             self.shipped_edit.setText(safe_str(data.get("shipped")))
@@ -441,6 +447,7 @@ class ModernShipmentDialog(QDialog):
                 "description": self.description_edit.toPlainText().strip(),
                 "status": actual_status,
                 "qc_release": self.qc_release_edit.text().strip(),
+                "qc_notes": self.qc_notes_edit.text().strip(),
                 "created": self.created_edit.text().strip(),
                 "ship_plan": self.ship_plan_edit.text().strip(),
                 "shipped": self.shipped_edit.text().strip(),

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -56,6 +56,7 @@ class ShipmentCreate(BaseModel):
     description: str = ""
     status: str = "partial_release"
     qc_release: str = ""
+    qc_notes: str = ""
     created: str = ""
     ship_plan: str = ""
     shipped: str = ""
@@ -68,6 +69,7 @@ class ShipmentUpdate(BaseModel):
     description: str = None
     status: str = None
     qc_release: str = None
+    qc_notes: str = None
     created: str = None
     ship_plan: str = None
     shipped: str = None
@@ -82,6 +84,7 @@ class ShipmentResponse(BaseModel):
     description: str
     status: str
     qc_release: str
+    qc_notes: str
     created: str
     ship_plan: str
     shipped: str
@@ -380,6 +383,7 @@ async def delete_shipment(
         "description": shipment.description,
         "status": shipment.status,
         "qc_release": shipment.qc_release,
+        "qc_notes": shipment.qc_notes,
         "created": shipment.created,
         "ship_plan": shipment.ship_plan,
         "shipped": shipment.shipped,

--- a/ShippingServer/models.py
+++ b/ShippingServer/models.py
@@ -34,6 +34,7 @@ class Shipment(Base):
     
     # Fechas
     qc_release = Column(String(20))  # Formato: MM/DD/YY
+    qc_notes = Column(Text)
     created = Column(String(20))     # Formato: MM/DD/YY
     ship_plan = Column(String(20))   # Formato: MM/DD/YY  
     shipped = Column(String(20))     # Formato: MM/DD/YY

--- a/ShippingServer/utils.py
+++ b/ShippingServer/utils.py
@@ -33,6 +33,7 @@ class Shipment(Base):
     
     # Fechas
     qc_release = Column(String(20))  # Formato: MM/DD/YY
+    qc_notes = Column(Text)
     created = Column(String(20))     # Formato: MM/DD/YY
     ship_plan = Column(String(20))   # Formato: MM/DD/YY  
     shipped = Column(String(20))     # Formato: MM/DD/YY


### PR DESCRIPTION
## Summary
- add `qc_notes` column in models
- expose QC notes via API schemas
- update deletion audit backup
- display QC Notes in shipment form and table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f77e35148331b15eefac702187a3