### PR TITLE
Remember last login

### DIFF
--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -41,3 +41,16 @@ class SettingsManager:
                 widths.append(None)
         self._settings.endGroup()
         return widths
+
+    def get_last_username(self) -> str:
+        """Return the last used username or empty string."""
+        return self._settings.value("last_username", "")
+
+    def get_last_password(self) -> str:
+        """Return the last used password or empty string."""
+        return self._settings.value("last_password", "")
+
+    def set_last_credentials(self, username: str, password: str):
+        """Persist last used username and password."""
+        self._settings.setValue("last_username", username)
+        self._settings.setValue("last_password", password)

--- a/ShippingClient/ui/login_dialog.py
+++ b/ShippingClient/ui/login_dialog.py
@@ -98,6 +98,8 @@ class ModernLoginDialog(QDialog):
         main_layout.addWidget(background_frame)
 
         self.setLayout(main_layout)
+        # Prefill fields with last used credentials if available
+        self.load_last_credentials()
     
     def create_login_header(self, layout):
         """Crear header del login con logo"""
@@ -220,8 +222,13 @@ class ModernLoginDialog(QDialog):
 
         footer_layout.addWidget(separator)
         footer_layout.addLayout(connection_layout)
-        
+
         layout.addLayout(footer_layout)
+
+    def load_last_credentials(self):
+        """Fill username and password fields with last used credentials."""
+        self.username_edit.setText(self.settings_mgr.get_last_username())
+        self.password_edit.setText(self.settings_mgr.get_last_password())
     
     def login(self):
         """Realizar proceso de login"""
@@ -250,6 +257,8 @@ class ModernLoginDialog(QDialog):
                 self.token = data["access_token"]
                 self.user_info = data["user_info"]
                 print(f"Login successful for user: {username}")
+                # Store credentials for next session
+                self.settings_mgr.set_last_credentials(username, password)
                 self.accept()
             else:
                 error_data = response.json() if response.headers.get('content-type') == 'application/json' else {}


### PR DESCRIPTION
## Summary
- store last used username and password in `SettingsManager`
- pre-fill login dialog from stored credentials
- store credentials after successful login

## Testing
- `python -m py_compile ShippingClient/ui/login_dialog.py ShippingClient/core/settings_manager.py`
- `find ShippingClient -name '*.py' -print0 | xargs -0 python -m py_compile`
- `find ShippingServer -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6878dac2fbfc833194c32bc1019e974b