### PR TITLE
Fix display of created date

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -809,7 +809,7 @@ class ModernShippingMainWindow(QMainWindow):
             shipment.get("status", ""),
             shipment.get("qc_release", ""),
             shipment.get("qc_notes", ""),
-            shipment.get("crated", ""),
+            shipment.get("created", ""),
             shipment.get("ship_plan", ""),
             shipment.get("shipped", ""),
             shipment.get("invoice_number", ""),
@@ -835,7 +835,7 @@ class ModernShippingMainWindow(QMainWindow):
             
             table.setItem(row, col, item)
 
-        crated = shipment.get("crated")
+        crated = shipment.get("created")
         shipped = shipment.get("shipped")
         if crated and not shipped and job_item is not None:
             job_item.setBackground(QColor("#FEF3C7"))


### PR DESCRIPTION
## Summary
- show shipment `created` field in the 'Crated' column

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687934e5d720833187c5be1531d12494