### PR TITLE
Enable wrapped text in table rows

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -504,10 +504,9 @@ class ModernShippingMainWindow(QMainWindow):
         table.verticalHeader().setVisible(False)
         table.setShowGrid(True)
         table.setWordWrap(True)
-        # Usar altura fija para filas en lugar de recalcular para cada dato,
-        # lo cual resulta muy costoso con miles de registros
-        table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
-        table.verticalHeader().setDefaultSectionSize(45)
+        # Ajustar altura automáticamente para permitir que el texto se envuelva
+        # en múltiples líneas cuando sea necesario
+        table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
         
         # Optimización de performance
         table.setVerticalScrollMode(QTableWidget.ScrollMode.ScrollPerPixel)


### PR DESCRIPTION
## Summary
- expand row heights automatically to allow wrapped text for long cell values

## Testing
- `python -m py_compile ShippingClient/ui/main_window.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a493f0fb48331b4f9f38bfdd865e8