### PR TITLE
Add success notifications

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -660,9 +660,9 @@ class ModernShippingMainWindow(QMainWindow):
     
     
 
-    def show_toast(self, message):
+    def show_toast(self, message, color="#3B82F6"):
         """Mostrar notificación visual flotante"""
-        show_popup_notification(self, message)
+        show_popup_notification(self, message, color=color)
     
     def on_tab_changed(self, index):
         """Manejar cambio de tab optimizado"""
@@ -957,6 +957,7 @@ class ModernShippingMainWindow(QMainWindow):
             dialog = ModernShipmentDialog(token=self.token)
             if dialog.exec() == QDialog.DialogCode.Accepted:
                 self.load_shipments_async()
+                self.show_toast("Shipment saved successfully", color="#16A34A")
         except Exception as e:
             print(f"Error abriendo diálogo de nuevo shipment: {e}")
             self.show_error(f"Error opening new shipment dialog: {str(e)}")
@@ -989,6 +990,7 @@ class ModernShippingMainWindow(QMainWindow):
             dialog = ModernShipmentDialog(shipment_data=shipment_data, token=self.token)
             if dialog.exec() == QDialog.DialogCode.Accepted:
                 self.load_shipments_async()
+                self.show_toast("Changes saved successfully", color="#16A34A")
         except Exception as e:
             print(f"Error editando shipment: {e}")
             self.show_error(f"Error editing shipment: {str(e)}")

--- a/ShippingClient/ui/utils.py
+++ b/ShippingClient/ui/utils.py
@@ -3,12 +3,12 @@ from PyQt6.QtWidgets import QLabel
 from PyQt6.QtCore import QTimer, Qt, QPoint
 from core.config import MODERN_FONT
 
-def show_popup_notification(parent, message, duration=3000):
+def show_popup_notification(parent, message, duration=3000, color="#3B82F6"):
     popup = QLabel(parent)
     popup.setText(f"  ●  {message}")
     popup.setStyleSheet(f"""
         QLabel {{
-            background-color: #3B82F6;
+            background-color: {color};
             color: white;
             padding: 12px 22px;
             border-radius: 10px;


### PR DESCRIPTION
## Summary
- allow configuring popup notification color
- use the success color for shipment add/edit confirmations

## Testing
- `python -m py_compile ShippingClient/ui/utils.py ShippingClient/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_687a4be5eee083318a467d7ba3f711b7