### PR TITLE
Fix edit/delete after sorting

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -831,6 +831,8 @@ class ModernShippingMainWindow(QMainWindow):
                 item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
             if col == 0:
                 job_item = item
+                # store full shipment data for easy retrieval even after sorting
+                item.setData(Qt.ItemDataRole.UserRole, shipment)
             
             table.setItem(row, col, item)
 
@@ -973,17 +975,12 @@ class ModernShippingMainWindow(QMainWindow):
                 return
             
             row = selected_rows[0].row()
-            
-            # Obtener datos según el tab actual
-            if self.tab_widget.currentIndex() == 0:  # Active
-                filtered_shipments = self.apply_filters_to_shipments(self._active_shipments, True)
-            else:  # History
-                filtered_shipments = self.apply_filters_to_shipments(self._history_shipments, False)
-            
-            if row >= len(filtered_shipments):
+            shipment_item = current_table.item(row, 0)
+            if not shipment_item:
                 return
-                
-            shipment_data = filtered_shipments[row]
+            shipment_data = shipment_item.data(Qt.ItemDataRole.UserRole)
+            if not shipment_data:
+                return
             
             from .shipment_dialog import ModernShipmentDialog
             
@@ -1006,17 +1003,12 @@ class ModernShippingMainWindow(QMainWindow):
                 return
             
             row = selected_rows[0].row()
-            
-            # Obtener datos según el tab actual
-            if self.tab_widget.currentIndex() == 0:  # Active
-                filtered_shipments = self.apply_filters_to_shipments(self._active_shipments, True)
-            else:  # History
-                filtered_shipments = self.apply_filters_to_shipments(self._history_shipments, False)
-            
-            if row >= len(filtered_shipments):
+            shipment_item = current_table.item(row, 0)
+            if not shipment_item:
                 return
-                
-            shipment = filtered_shipments[row]
+            shipment = shipment_item.data(Qt.ItemDataRole.UserRole)
+            if not shipment:
+                return
             
             # Confirmación profesional
             msg = QMessageBox(self)


### PR DESCRIPTION
## Summary
- ensure shipments retrieved from the selected row when table is sorted
- store shipment data on table item for reliable retrieval during edit and delete

## Testing
- `python -m py_compile ShippingClient/ui/main_window.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8c11a5d88331ae637af5032571d3