### PR TITLE
Enable calendar popup for date editing

### DIFF
--- a/ShippingClient/ui/date_delegate.py
+++ b/ShippingClient/ui/date_delegate.py
@@ -1,0 +1,26 @@
+from PyQt6.QtWidgets import QStyledItemDelegate, QDateEdit
+from PyQt6.QtCore import Qt, QDate
+
+class DateDelegate(QStyledItemDelegate):
+    """Delegate that shows a calendar popup when editing date cells."""
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def createEditor(self, parent, option, index):
+        editor = QDateEdit(parent)
+        editor.setCalendarPopup(True)
+        editor.setDisplayFormat("MM/dd/yy")
+        return editor
+
+    def setEditorData(self, editor, index):
+        text = index.data(Qt.ItemDataRole.EditRole)
+        date = QDate.fromString(text, "MM/dd/yy")
+        if not date.isValid():
+            date = QDate.fromString(text, "MM/dd/yyyy")
+        if not date.isValid():
+            date = QDate.currentDate()
+        editor.setDate(date)
+
+    def setModelData(self, editor, model, index):
+        date_str = editor.date().toString("MM/dd/yy")
+        model.setData(index, date_str, Qt.ItemDataRole.EditRole)

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -27,6 +27,7 @@ from PyQt6.QtGui import QFont, QColor, QPixmap, QPalette, QIcon, QDesktopService
 
 # Imports locales
 from .widgets import ModernButton, ModernLineEdit, ModernComboBox
+from .date_delegate import DateDelegate
 from .settings_dialog import SettingsDialog
 from core.websocket_client import WebSocketClient
 from core.config import (
@@ -533,6 +534,11 @@ class ModernShippingMainWindow(QMainWindow):
         header = table.horizontalHeader()
         for i in range(len(columns)):
             header.setSectionResizeMode(i, QHeaderView.ResizeMode.Interactive)
+
+        # Delegates para campos de fecha
+        date_delegate = DateDelegate(table)
+        for col in (4, 6, 7, 8):
+            table.setItemDelegateForColumn(col, date_delegate)
 
         # Restaurar anchos guardados si existen
         self.restore_column_widths(table, name)


### PR DESCRIPTION
## Summary
- introduce `DateDelegate` to provide calendar selection when editing date fields
- use the new delegate in `main_window` for QC Release, Crated, Ship Plan and Shipped columns

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687f9a708894833186965d84d1d6cdd1