### PR TITLE
Fix job number color

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -873,7 +873,8 @@ class ModernShippingMainWindow(QMainWindow):
 
         # Color de la celda de Job Number según el status
         if job_item is not None:
-            status = shipment.get("status", "")
+            raw_status = shipment.get("status", "")
+            status = str(raw_status).strip().lower().replace(" ", "_")
             if status == "partial_release":
                 job_item.setData(Qt.ItemDataRole.BackgroundRole, QBrush(QColor("#FEF3C7")))
             elif status == "final_release":


### PR DESCRIPTION
## Summary
- standardize status strings when coloring Job Number cells

## Testing
- `pip list | grep PyQt`

------
https://chatgpt.com/codex/tasks/task_e_687fc9993d308331b68d050ec9521dce