### PR TITLE
Fix job number highlighting

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -864,13 +864,6 @@ class ModernShippingMainWindow(QMainWindow):
 
             table.setItem(row, col, item)
 
-        crated = shipment.get("created")
-        if crated and not self.is_shipped(shipment) and job_item is not None:
-            # Highlight job number when there's a creation date but no valid
-            # shipped date. We reuse the same check as `is_shipped` so values
-            # like "pending" or "n/a" are treated as not shipped.
-            job_item.setData(Qt.ItemDataRole.BackgroundRole, QBrush(QColor("#FEF3C7")))
-
         # Color de la celda de Job Number según el status
         if job_item is not None:
             raw_status = shipment.get("status", "")


### PR DESCRIPTION
## Summary
- remove date-based coloring for job numbers
- rely solely on shipment status for highlighting

## Testing
- `python3 -m py_compile ui/main_window.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fce0348948331912cf97530bc010f