### PR TITLE
Remove background override on table items

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -490,7 +490,7 @@ class ModernShippingMainWindow(QMainWindow):
                 border-right: 1px solid #E5E7EB;
             }}
             QTableWidget::item:selected {{
-                background: #EFF6FF;
+                /* Remove background so per-item colors remain visible */
                 color: #1F2937;
             }}
             QHeaderView::section {{


### PR DESCRIPTION
## Summary
- preserve custom cell colors by eliminating the selected-item background in `setup_professional_table`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fd28fb0a88331a0bbb1ea6ebd36cf