### PR TITLE
Restore professional table styling

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -473,48 +473,48 @@ class ModernShippingMainWindow(QMainWindow):
         table.setColumnCount(len(columns))
         table.setHorizontalHeaderLabels(columns)
         
-        # Estilo profesional para la tabla (temporalmente deshabilitado)
-        # table.setStyleSheet(f"""
-        #     QTableWidget {{
-        #         background: #FFFFFF;
-        #         border: none;
-        #         gridline-color: #E5E7EB;
-        #         font-family: '{MODERN_FONT}';
-        #         font-size: 12px;
-        #         selection-background-color: #EFF6FF;
-        #         selection-color: #1F2937;
-        #     }}
-        #     QTableWidget::item {{
-        #         padding: 12px 8px;
-        #         border-bottom: 1px solid #E5E7EB;
-        #         border-right: 1px solid #E5E7EB;
-        #     }}
-        #     QTableWidget::item:selected {{
-        #         /* Remove background so per-item colors remain visible */
-        #         color: #1F2937;
-        #     }}
-        #     QHeaderView::section {{
-        #         background-color: #F9FAFB;
-        #         color: #374151;
-        #         padding: 12px 8px;
-        #         border: none;
-        #         border-bottom: 2px solid #E5E7EB;
-        #         border-right: 1px solid #E5E7EB;
-        #         font-weight: 600;
-        #         font-size: 11px;
-        #         text-transform: uppercase;
-        #         letter-spacing: 0.5px;
-        #     }}
-        #     QHeaderView::section:first {{
-        #         border-left: none;
-        #     }}
-        #     QHeaderView::section:last {{
-        #         border-right: none;
-        #     }}
-        #     QTableWidget::item:hover {{
-        #         background: #F9FAFB;
-        #     }}
-        # """)
+        # Estilo profesional para la tabla
+        table.setStyleSheet(
+            f"""
+            QTableWidget {{
+                background: #FFFFFF;
+                border: none;
+                gridline-color: #E5E7EB;
+                font-family: '{MODERN_FONT}';
+                font-size: 12px;
+                selection-background-color: #EFF6FF;
+                selection-color: #1F2937;
+            }}
+            QTableWidget::item {{
+                padding: 12px 8px;
+                border-bottom: 1px solid #E5E7EB;
+                border-right: 1px solid #E5E7EB;
+                /* NO poner background aquí - deja que el código lo maneje */
+            }}
+            QTableWidget::item:selected {{
+                /* NO poner background aquí tampoco - solo texto */
+                color: #1F2937;
+            }}
+            QHeaderView::section {{
+                background-color: #F9FAFB;
+                color: #374151;
+                padding: 12px 8px;
+                border: none;
+                border-bottom: 2px solid #E5E7EB;
+                border-right: 1px solid #E5E7EB;
+                font-weight: 600;
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.5px;
+            }}
+            QHeaderView::section:first {{
+                border-left: none;
+            }}
+            QHeaderView::section:last {{
+                border-right: none;
+            }}
+            """
+        )
         
         # Configuración
         table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)


### PR DESCRIPTION
## Summary
- enable professional table stylesheet in `main_window.py`
- ensure no background colors are set for `QTableWidget::item` or `QTableWidget::item:selected`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687fdec406dc8331ad38db8832c50f7e