### PR TITLE
Restore professional table CSS

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -481,13 +481,6 @@ class ModernShippingMainWindow(QMainWindow):
         background: #FFFFFF;
         gridline-color: #E5E7EB;
         border: 1px solid #E5E7EB;
-        selection-background-color: #EFF6FF;
-        selection-color: #1F2937;
-    }}
-    QTableWidget::item {{
-        padding: 8px;
-        border-right: 1px solid #E5E7EB;
-        border-bottom: 1px solid #E5E7EB;
     }}
     QHeaderView::section {{
         background-color: #F9FAFB;


### PR DESCRIPTION
## Summary
- revert the professional table styling to the working CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880ca64fbb883318a2bf74ab2082079