### PR TITLE
Persist table cell highlight

### DIFF
--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -1,3 +1,4 @@
+import json
 from PyQt6.QtCore import QSettings
 
 
@@ -21,6 +22,27 @@ class SettingsManager:
 
     def set_ws_url(self, url: str):
         self._settings.setValue("ws_url", url)
+
+    def save_cell_colors(self, table_name: str, colors: dict[tuple[int, int], str]):
+        """Persist background colors for table cells."""
+        serialized = {f"{r},{c}": color for (r, c), color in colors.items()}
+        self._settings.setValue(f"{table_name}_cell_colors", json.dumps(serialized))
+
+    def load_cell_colors(self, table_name: str) -> dict[tuple[int, int], str]:
+        """Retrieve stored background colors for table cells."""
+        data = self._settings.value(f"{table_name}_cell_colors", "{}")
+        try:
+            raw = json.loads(data)
+        except Exception:
+            return {}
+        result: dict[tuple[int, int], str] = {}
+        for key, color in raw.items():
+            try:
+                r_str, c_str = key.split(",")
+                result[(int(r_str), int(c_str))] = color
+            except Exception:
+                continue
+        return result
 
     def save_column_widths(self, table_name: str, widths: list[int]):
         """Persist column widths for a table."""


### PR DESCRIPTION
## Summary
- allow marking table cells with an "Update" context menu option
- persist and restore cell background colors using QSettings

## Testing
- `python -m py_compile ShippingClient/core/settings_manager.py ShippingClient/ui/main_window.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4d43acb88331b104d90dd50faed9