### PR TITLE
Improve PDF print layout for job names

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1212,8 +1212,8 @@ class ModernShippingMainWindow(QMainWindow):
             doc = SimpleDocTemplate(
                 file_path,
                 pagesize=letter,
-                leftMargin=20,
-                rightMargin=20,
+                leftMargin=10,
+                rightMargin=10,
                 topMargin=20,
                 bottomMargin=20,
             )
@@ -1231,9 +1231,12 @@ class ModernShippingMainWindow(QMainWindow):
                 "Crated",
                 "Ship Plan",
             ]]
+            max_name_len = 18
             for row in range(rows):
                 job = current_table.item(row, 0).text() if current_table.item(row, 0) else ""
                 name = current_table.item(row, 1).text() if current_table.item(row, 1) else ""
+                if len(name) > max_name_len:
+                    name = name[: max_name_len - 1] + "…"
                 desc = current_table.item(row, 2).text() if current_table.item(row, 2) else ""
                 qc_rel = current_table.item(row, 4).text() if current_table.item(row, 4) else ""
                 crated = current_table.item(row, 6).text() if current_table.item(row, 6) else ""
@@ -1253,8 +1256,8 @@ class ModernShippingMainWindow(QMainWindow):
             width = doc.width
             col_widths = [
                 width * 0.15,  # Job Number
-                width * 0.2,   # Job Name
-                width * 0.3,   # Description
+                width * 0.15,  # Job Name
+                width * 0.35,  # Description
                 width * 0.1,   # QC Release
                 width * 0.1,   # Crated
                 width * 0.15,  # Ship Plan


### PR DESCRIPTION
## Summary
- Truncate job names to keep PDF export cells to a single line

## Testing
- `python -m py_compile ShippingClient/ui/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b59ac78f083319ffbc34af7cc841b