### PR TITLE
Improve table header colors for printing

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -486,8 +486,8 @@ class ModernShippingMainWindow(QMainWindow):
         border: 1px solid #E5E7EB;
     }}
     QHeaderView::section {{
-        background-color: #F9FAFB;
-        color: #374151;
+        background-color: #E5E5E5;
+        color: #000000;
         padding: 12px 8px;
         border: none;
         border-bottom: 2px solid #E5E7EB;

--- a/ShippingClient/ui/user_dialog.py
+++ b/ShippingClient/ui/user_dialog.py
@@ -130,6 +130,15 @@ class UserManagementDialog(QDialog):
         self.table = QTableWidget(0, 4)
         self.table.setHorizontalHeaderLabels(["ID", "Username", "Email", "Role"])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.table.setStyleSheet("""
+    QHeaderView::section {
+        background-color: #E5E5E5;
+        color: #000000;
+        padding: 8px 4px;
+        border: none;
+        border-right: 1px solid #D1D5DB;
+    }
+        """)
         layout.addWidget(self.table)
 
         btn_layout = QHBoxLayout()


### PR DESCRIPTION
## Summary
- Switch table headers to light gray backgrounds with black text for better black-and-white printing
- Apply consistent header styling to user management table

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3137d36fc8331bb7abcd5b789a704