### PR TITLE
Simplify Ship Plan sorting without proxy model

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -524,17 +524,6 @@ class ModernShippingMainWindow(QMainWindow):
         status_delegate = StatusDelegate(table)
         table.setItemDelegateForColumn(3, status_delegate)
 
-        from PyQt6.QtCore import QSortFilterProxyModel
-
-        # Custom sorting para Ship Plan
-        class ShipPlanSortModel(QSortFilterProxyModel):
-            def lessThan(self, left, right):
-                if left.column() == 7:  # Ship Plan column
-                    left_data = self.sourceModel().data(left, Qt.ItemDataRole.UserRole + 1)
-                    right_data = self.sourceModel().data(right, Qt.ItemDataRole.UserRole + 1)
-                    return str(left_data or "") < str(right_data or "")
-                return super().lessThan(left, right)
-
         # Restaurar anchos guardados si existen
         self.restore_column_widths(table, name)
 
@@ -552,11 +541,6 @@ class ModernShippingMainWindow(QMainWindow):
         # Habilitar ordenamiento por columnas
         table.setSortingEnabled(True)
         header.setSortIndicatorShown(True)
-
-        # Habilitar sorting custom para Ship Plan
-        proxy_model = ShipPlanSortModel()
-        proxy_model.setSourceModel(table.model())
-        table.setModel(proxy_model)
 
     def save_table_column_widths(self, table, name):
         """Guardar anchos actuales de la tabla."""
@@ -884,9 +868,12 @@ class ModernShippingMainWindow(QMainWindow):
                 self.style_professional_status_item(item, item_text)
             else:
                 if col == 7:  # Solo Ship Plan
-                    sort_value = "9999/12/31" if not str(item_text).strip() else str(item_text)
-                    item = QTableWidgetItem(str(item_text))
-                    item.setData(Qt.ItemDataRole.UserRole + 1, sort_value)
+                    item = QTableWidgetItem()
+                    display_text = str(item_text) if str(item_text).strip() else ""
+                    sort_text = "🔹" if not str(item_text).strip() else str(item_text)
+
+                    item.setText(display_text)
+                    item.setData(Qt.ItemDataRole.DisplayRole, sort_text)
                 else:
                     item = QTableWidgetItem(str(item_text))
                 if not is_active and col == 8 and item_text:  # Shipped en history


### PR DESCRIPTION
## Summary
- remove custom QSortFilterProxyModel and ShipPlanSortModel
- handle Ship Plan sorting by inserting placeholder for empty values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a31ce360508331a83323b474bfeb9b