### PR TITLE
Fix ship plan blank cell sorting

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -870,10 +870,10 @@ class ModernShippingMainWindow(QMainWindow):
                 if col == 7:  # Solo Ship Plan
                     item = QTableWidgetItem()
                     display_text = str(item_text) if str(item_text).strip() else ""
-                    sort_text = "🔹" if not str(item_text).strip() else str(item_text)
+                    sort_text = "zzzzz" if not str(item_text).strip() else str(item_text)
 
                     item.setText(display_text)
-                    item.setData(Qt.ItemDataRole.DisplayRole, sort_text)
+                    item.setData(Qt.ItemDataRole.UserRole, sort_text)
                 else:
                     item = QTableWidgetItem(str(item_text))
                 if not is_active and col == 8 and item_text:  # Shipped en history


### PR DESCRIPTION
## Summary
- keep Ship Plan column visually blank when no date
- sort Ship Plan using UserRole instead of DisplayRole

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a31fb0bf348331865c0fc0ff7b60ae