### PR TITLE
Validate auth token and ensure API client usage in UI

### DIFF
--- a/ShippingClient/core/api_client.py
+++ b/ShippingClient/core/api_client.py
@@ -27,6 +27,9 @@ class RobustApiClient:
     """Cliente API con retry automático y manejo robusto de errores"""
 
     def __init__(self, base_url: str, token: str, max_retries: int = 3, timeout: int = 10):
+        if not token or not token.strip():
+            raise ValueError("A valid authentication token must be provided")
+
         self.base_url = base_url.rstrip('/')
         self.token = token
         self.max_retries = max_retries


### PR DESCRIPTION
## Summary
- validate that a non-empty auth token is supplied before initializing the API client session
- pass RobustApiClient instance into shipment dialog and background shipment loader

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7283a6dac83319b431f45e88d4e0a