### PR TITLE
Allow API client initialization without token

### DIFF
--- a/ShippingClient/core/api_client.py
+++ b/ShippingClient/core/api_client.py
@@ -26,20 +26,23 @@ class ApiResponse:
 class RobustApiClient:
     """Cliente API con retry automático y manejo robusto de errores"""
 
-    def __init__(self, base_url: str, token: str, max_retries: int = 3, timeout: int = 10):
-        if not token or not token.strip():
-            raise ValueError("A valid authentication token must be provided")
-
+    def __init__(
+        self,
+        base_url: str,
+        token: Optional[str] = None,
+        max_retries: int = 3,
+        timeout: int = 10,
+    ):
         self.base_url = base_url.rstrip('/')
-        self.token = token
+        self.token = token.strip() if token else None
         self.max_retries = max_retries
         self.timeout = timeout
 
         self.session = requests.Session()
-        self.session.headers.update({
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json"
-        })
+        headers = {"Content-Type": "application/json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        self.session.headers.update(headers)
 
     def update_token(self, new_token: str):
         """Actualizar token de autenticación"""

--- a/ShippingClient/ui/login_dialog.py
+++ b/ShippingClient/ui/login_dialog.py
@@ -245,7 +245,7 @@ class ModernLoginDialog(QDialog):
         self.password_edit.setEnabled(False)
         
         try:
-            temp_client = RobustApiClient(get_server_url(), "", max_retries=2)
+            temp_client = RobustApiClient(get_server_url(), max_retries=2)
             api_response = temp_client.login(username, password)
 
             if api_response.is_success():

--- a/test_api_client.py
+++ b/test_api_client.py
@@ -15,5 +15,19 @@ def test_api_client():
     print("\u2705 Test b\u00e1sico pasado")
 
 
+def test_api_client_without_token():
+    """El cliente debe poder inicializarse sin token para el login"""
+    client = RobustApiClient("http://invalid-server:9999")
+    response = client.login("user", "pass")
+
+    print(f"Success: {response.success}")
+    print(f"Error: {response.error}")
+
+    assert not response.success
+    assert response.error
+
+    print("\u2705 Test sin token pasado")
+
+
 if __name__ == "__main__":
     test_api_client()


### PR DESCRIPTION
## Summary
- allow `RobustApiClient` to initialize without an auth token
- use optional token when logging in
- cover login without token in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72af329fc8331bb9227da6c5e96fa