### PR TITLE
feat: add optional credential memory

### DIFF
--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -67,12 +67,16 @@ class SettingsManager:
     def get_last_username(self) -> str:
         """Return the last used username or empty string."""
         return self._settings.value("last_username", "")
+    def should_remember_credentials(self) -> bool:
+        """Return True if credentials should be remembered."""
+        return self._settings.value("remember_credentials", False, bool)
 
-    def get_last_password(self) -> str:
-        """Return the last used password or empty string."""
-        return self._settings.value("last_password", "")
-
-    def set_last_credentials(self, username: str, password: str):
-        """Persist last used username and password."""
-        self._settings.setValue("last_username", username)
-        self._settings.setValue("last_password", password)
+    def save_credentials(self, username: str, remember: bool):
+        """Persist last used username when requested, otherwise clear stored data."""
+        if remember:
+            self._settings.setValue("last_username", username)
+            self._settings.setValue("remember_credentials", True)
+        else:
+            self._settings.remove("last_username")
+            self._settings.remove("last_password")
+            self._settings.setValue("remember_credentials", False)

--- a/ShippingClient/ui/login_dialog.py
+++ b/ShippingClient/ui/login_dialog.py
@@ -9,6 +9,7 @@ from PyQt6.QtWidgets import (
     QMessageBox,
     QLineEdit,
     QStyle,
+    QCheckBox,
 )
 from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QFont, QIcon
@@ -161,13 +162,18 @@ class ModernLoginDialog(QDialog):
         
         self.password_edit = ModernLineEdit("Enter your password")
         self.password_edit.setEchoMode(QLineEdit.EchoMode.Password)
-        
+
         password_layout.addWidget(password_label)
         password_layout.addWidget(self.password_edit)
-        
+
+        # Remember me checkbox
+        self.remember_checkbox = QCheckBox("Remember me")
+        self.remember_checkbox.setChecked(False)
+
         form_layout.addLayout(username_layout)
         form_layout.addLayout(password_layout)
-        
+        form_layout.addWidget(self.remember_checkbox)
+
         layout.addLayout(form_layout)
     
     def create_login_buttons(self, layout):
@@ -234,9 +240,10 @@ class ModernLoginDialog(QDialog):
         layout.addLayout(footer_layout)
 
     def load_last_credentials(self):
-        """Fill username and password fields with last used credentials."""
-        self.username_edit.setText(self.settings_mgr.get_last_username())
-        self.password_edit.setText(self.settings_mgr.get_last_password())
+        """Fill username field with last used credentials if requested."""
+        if self.settings_mgr.should_remember_credentials():
+            self.username_edit.setText(self.settings_mgr.get_last_username())
+            self.remember_checkbox.setChecked(True)
 
     def check_server_connection(self):
         """Check server connectivity and update footer indicator."""
@@ -279,7 +286,7 @@ class ModernLoginDialog(QDialog):
                 self.token = data["access_token"]
                 self.user_info = data["user_info"]
                 print(f"Login successful for user: {username}")
-                self.settings_mgr.set_last_credentials(username, password)
+                self.settings_mgr.save_credentials(username, self.remember_checkbox.isChecked())
                 self.accept()
             else:
                 self.show_professional_error(api_response.get_error())


### PR DESCRIPTION
## Summary
- add 'Remember me' checkbox to login dialog
- store last username only when checkbox is checked
- update SettingsManager for optional credential persistence

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a730c5d57883319f3366995e291d0a