### PR TITLE
Move Mie Trak address lookup to client

### DIFF
--- a/ShippingClient/core/api_client.py
+++ b/ShippingClient/core/api_client.py
@@ -175,7 +175,3 @@ class RobustApiClient:
     def login(self, username: str, password: str) -> ApiResponse:
         """Autenticar usuario"""
         return self.post("/login", data={"username": username, "password": password})
-
-    def get_mie_trak_address(self, job_number: str) -> ApiResponse:
-        """Obtener dirección de Mie Trak para un job"""
-        return self.get(f"/mie-trak/address/{job_number}")

--- a/ShippingClient/core/mie_trak_client.py
+++ b/ShippingClient/core/mie_trak_client.py
@@ -1,0 +1,72 @@
+"""Utility functions to query Mie Trak directly from the client."""
+
+from typing import Any, List
+import pymssql
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_mie_trak_address(job_number: str) -> str:
+    """Return the shipping address for a given job number.
+
+    This function connects directly to the Mie Trak database, queries the
+    address information and closes the connection before returning.
+    """
+    raw_job_number = job_number
+    cleaned_job_number = str(job_number).strip()
+
+    variants: List[Any] = [cleaned_job_number]
+    if cleaned_job_number.isdigit():
+        variants.extend([
+            cleaned_job_number.zfill(len(cleaned_job_number) + 1),
+            int(cleaned_job_number),
+        ])
+    variants = list(dict.fromkeys(variants))
+
+    conn = None
+    try:
+        conn = pymssql.connect(
+            server="GUNDMAIN",
+            user="mie",
+            password="mie",
+            database="GunderlinLive",
+        )
+        cursor = conn.cursor(as_dict=True)
+
+        query = (
+            """
+            SELECT ShippingAddress1, ShippingAddress2,
+                   ShippingAddressCity, ShippingAddressStateDescription,
+                   ShippingAddressZipCode
+            FROM SalesOrder
+            WHERE SalesOrderPK = %s
+            """
+        )
+
+        row = None
+        for variant in variants:
+            cursor.execute(query, (variant,))
+            row = cursor.fetchone()
+            if row:
+                break
+
+        if not row:
+            raise ValueError(
+                f"Job number {raw_job_number} not found. Variants tried: {variants}"
+            )
+
+        address_parts = [row.get("ShippingAddress1"), row.get("ShippingAddress2")]
+        city_line = (
+            f"{row.get('ShippingAddressCity')},{row.get('ShippingAddressStateDescription')} "
+            f"{row.get('ShippingAddressZipCode')}"
+        )
+        address_parts.append(city_line)
+        return "\n".join(part for part in address_parts if part)
+
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -7,6 +7,7 @@ from html import escape
 from .utils import show_popup_notification
 from core.settings_manager import SettingsManager
 from core.api_client import RobustApiClient
+from core.mie_trak_client import get_mie_trak_address
 from PyQt6.QtWidgets import (
     QMainWindow,
     QWidget,
@@ -661,14 +662,12 @@ class ModernShippingMainWindow(QMainWindow):
             self.show_error(f"Failed to save changes: {str(e)}")
 
     def show_mie_trak_address(self, job_number: str):
-        """Fetch and display Mie Trak address for a job"""
+        """Fetch and display Mie Trak address for a job directly from DB"""
         try:
-            api_response = self.api_client.get_mie_trak_address(job_number)
-            if api_response.is_success():
-                address = api_response.get_data().get("address", "")
-                QMessageBox.information(self, "Mie Trak Address", address or "No address found")
-            else:
-                self.show_error(api_response.get_error())
+            address = get_mie_trak_address(job_number)
+            QMessageBox.information(
+                self, "Mie Trak Address", address or "No address found"
+            )
         except Exception as e:
             self.show_error(str(e))
 

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -2,11 +2,10 @@
 from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
-from typing import List, Any
+from typing import List
 from datetime import timedelta
 import json
 import asyncio
-import pymssql
 import logging
 
 # Imports locales
@@ -458,81 +457,6 @@ async def root():
         "websocket": "/ws"
     }
 
-
-@app.get("/mie-trak/address/{job_number}")
-async def get_mie_trak_address(job_number: str):
-    raw_job_number = job_number
-    logger.info("Recibida solicitud de dirección para job_number=%s", raw_job_number)
-    cleaned_job_number = str(job_number).strip()
-    logger.debug("Job_number limpiado: '%s'", cleaned_job_number)
-
-    variants: List[Any] = [cleaned_job_number]
-    if cleaned_job_number.isdigit():
-        variants.extend([cleaned_job_number.zfill(len(cleaned_job_number) + 1), int(cleaned_job_number)])
-    # Eliminar duplicados conservando el orden
-    variants = list(dict.fromkeys(variants))
-    logger.debug("Variantes de búsqueda: %s", variants)
-
-    try:
-        logger.debug("Conectando a la base de datos GunderlinLive")
-        conn = pymssql.connect(
-            server="GUNDMAIN",
-            user="mie",
-            password="mie",
-            database="GunderlinLive",
-        )
-        cursor = conn.cursor(as_dict=True)
-
-        query = (
-            """
-            SELECT ShippingAddress1, ShippingAddress2,
-                   ShippingAddressCity, ShippingAddressStateDescription,
-                   ShippingAddressZipCode
-            FROM SalesOrder
-            WHERE SalesOrderPK = %s
-            """
-        )
-
-        row = None
-        for variant in variants:
-            logger.debug("Ejecutando consulta para job_number variante=%r", variant)
-            cursor.execute(query, (variant,))
-            row = cursor.fetchone()
-            logger.debug("Resultado para variante %r: %s", variant, row)
-            if row:
-                logger.debug("Registro encontrado usando variante=%r", variant)
-                break
-
-        if not row:
-            logger.warning(
-                "Job number %s no encontrado tras probar variantes %s", raw_job_number, variants
-            )
-            cursor.execute("SELECT TOP 5 SalesOrderPK FROM SalesOrder")
-            examples = [r["SalesOrderPK"] for r in cursor.fetchall()]
-            logger.info("Ejemplos de SalesOrderPK: %s", examples)
-            raise HTTPException(
-                status_code=404,
-                detail=f"Job number {raw_job_number} not found. Variants tried: {variants}",
-            )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.exception(
-            "Error al consultar la base de datos para job_number=%s", raw_job_number
-        )
-        raise HTTPException(status_code=500, detail=f"Database error: {str(e)}")
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-
-    address_parts = [row.get("ShippingAddress1"), row.get("ShippingAddress2")]
-    city_line = f"{row.get('ShippingAddressCity')},{row.get('ShippingAddressStateDescription')} {row.get('ShippingAddressZipCode')}"
-    address_parts.append(city_line)
-    address = "\n".join(part for part in address_parts if part)
-    logger.info("Enviando dirección para job_number=%s: %s", raw_job_number, address)
-    return {"address": address}
 
 @app.get("/audit-logs")
 async def get_audit_logs(limit: int = Query(100), db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):


### PR DESCRIPTION
## Summary
- Remove server endpoint that queried Mie Trak and drop related dependency.
- Add client-side module to query Mie Trak directly and close connections properly.
- Update UI to use new client-side lookup and delete obsolete API method.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a751e4d9448331b9b6eda326a31aa0