### PR TITLE
Trim job suffix before Mie Trak lookup

### DIFF
--- a/ShippingClient/core/mie_trak_client.py
+++ b/ShippingClient/core/mie_trak_client.py
@@ -16,6 +16,11 @@ def get_mie_trak_address(job_number: str) -> str:
     raw_job_number = job_number
     cleaned_job_number = str(job_number).strip()
 
+    # If the job number contains a suffix (e.g. "12345.1"), remove it before
+    # querying Mie Trak. The DB only stores the base number.
+    if "." in cleaned_job_number:
+        cleaned_job_number = cleaned_job_number.split(".", 1)[0]
+
     variants: List[Any] = [cleaned_job_number]
     if cleaned_job_number.isdigit():
         variants.extend([

--- a/test_mie_trak_client.py
+++ b/test_mie_trak_client.py
@@ -1,0 +1,31 @@
+import sys
+import types
+
+
+def test_suffix_is_trimmed(monkeypatch):
+    executed = []
+
+    class DummyCursor:
+        def execute(self, query, params):
+            executed.append(params[0])
+        def fetchone(self):
+            return {
+                "ShippingAddress1": "Addr1",
+                "ShippingAddressCity": "City",
+                "ShippingAddressStateDescription": "ST",
+                "ShippingAddressZipCode": "12345",
+            }
+
+    class DummyConn:
+        def cursor(self, as_dict=True):
+            return DummyCursor()
+        def close(self):
+            pass
+
+    dummy_pymssql = types.SimpleNamespace(connect=lambda *args, **kwargs: DummyConn())
+    sys.modules["pymssql"] = dummy_pymssql
+    from ShippingClient.core import mie_trak_client
+
+    address = mie_trak_client.get_mie_trak_address("12345.1")
+    assert executed[0] == "12345"
+    assert "Addr1" in address


### PR DESCRIPTION
## Summary
- Strip any suffix after a dot from job numbers before querying Mie Trak
- Add unit test ensuring suffixes are removed and address is still retrieved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7535b23788331b0d5f31c5cebe664