### PR TITLE
Fix logo path for packaged client

### DIFF
--- a/ShippingClient/core/config.py
+++ b/ShippingClient/core/config.py
@@ -1,4 +1,6 @@
 # core/config.py - Configuraciones centralizadas
+import os
+import sys
 from .settings_manager import SettingsManager
 
 DEFAULT_SERVER_URL = "http://localhost:8000"
@@ -31,3 +33,15 @@ CONNECTION_RETRY_INTERVAL = 5000  # 5 segundos
 # de toda la aplicación.
 MODERN_FONT = "Helvetica Neue"
 FONT_SIZE = 10
+
+# Recursos
+# Directorio base considerando ejecución congelada con PyInstaller
+BASE_DIR = getattr(sys, "_MEIPASS", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def resource_path(relative_path: str) -> str:
+    """Obtener ruta absoluta a un recurso empaquetado."""
+    return os.path.join(BASE_DIR, relative_path)
+
+
+LOGO_PATH = resource_path("assets/images/logo.png")

--- a/ShippingClient/main_client.py
+++ b/ShippingClient/main_client.py
@@ -6,13 +6,12 @@ from PyQt6.QtGui import QFont, QIcon
 
 # Imports locales
 from ui.login_dialog import ModernLoginDialog
-from core.config import MODERN_FONT, FONT_SIZE
+from core.config import MODERN_FONT, FONT_SIZE, LOGO_PATH
 
 def main():
     app = QApplication(sys.argv)
-    logo_path = "assets/images/logo.png"
-    if os.path.exists(logo_path):
-        app.setWindowIcon(QIcon(logo_path))
+    if os.path.exists(LOGO_PATH):
+        app.setWindowIcon(QIcon(LOGO_PATH))
 
     # Configurar fuente del sistema
     font = QFont(MODERN_FONT, FONT_SIZE)

--- a/ShippingClient/main_client.spec
+++ b/ShippingClient/main_client.spec
@@ -5,7 +5,7 @@ a = Analysis(
     ['main_client.py'],
     pathex=[],
     binaries=[],
-    datas=[],
+    datas=[('assets/images/logo.png', 'assets/images')],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/ShippingClient/ui/login_dialog.py
+++ b/ShippingClient/ui/login_dialog.py
@@ -24,15 +24,15 @@ from core.config import (
     LOGIN_HEIGHT,
     MODERN_FONT,
     CONNECTION_RETRY_INTERVAL,
+    LOGO_PATH,
 )
 
 class ModernLoginDialog(QDialog):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Shipping Schedule")
-        logo_path = "assets/images/logo.png"
-        if os.path.exists(logo_path):
-            self.setWindowIcon(QIcon(logo_path))
+        if os.path.exists(LOGO_PATH):
+            self.setWindowIcon(QIcon(LOGO_PATH))
         self.setMinimumSize(600, 600)
         self.setModal(True)
 

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -47,6 +47,7 @@ from core.config import (
     WINDOW_WIDTH,
     WINDOW_HEIGHT,
     MODERN_FONT,
+    LOGO_PATH,
 )
 
 class ShipmentLoader(QThread):
@@ -147,9 +148,8 @@ class ModernShippingMainWindow(QMainWindow):
         print(f"Inicializando ventana principal para usuario: {user_info['username']}")
         
         self.setWindowTitle("Shipping Schedule")
-        logo_path = "assets/images/logo.png"
-        if os.path.exists(logo_path):
-            self.setWindowIcon(QIcon(logo_path))
+        if os.path.exists(LOGO_PATH):
+            self.setWindowIcon(QIcon(LOGO_PATH))
         self.setGeometry(100, 100, WINDOW_WIDTH, WINDOW_HEIGHT)
         self.showMaximized()
         try:
@@ -223,9 +223,8 @@ class ModernShippingMainWindow(QMainWindow):
         
         # Intentar cargar el logo
         logo_label = QLabel()
-        logo_path = "assets/images/logo.png"
-        if os.path.exists(logo_path):
-            pixmap = QPixmap(logo_path)
+        if os.path.exists(LOGO_PATH):
+            pixmap = QPixmap(LOGO_PATH)
             # Escalar el logo manteniendo aspecto
             scaled_pixmap = pixmap.scaled(50, 50, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
             logo_label.setPixmap(scaled_pixmap)

--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -22,6 +22,7 @@ from core.config import (
     DIALOG_WIDTH,
     DIALOG_HEIGHT,
     MODERN_FONT,
+    LOGO_PATH,
 )
 
 class ModernShipmentDialog(QDialog):
@@ -91,10 +92,9 @@ class ModernShipmentDialog(QDialog):
         
         # Icono (usando logo si está disponible)
         icon_label = QLabel()
-        logo_path = "assets/images/logo.png"
-        
-        if os.path.exists(logo_path):
-            pixmap = QPixmap(logo_path)
+
+        if os.path.exists(LOGO_PATH):
+            pixmap = QPixmap(LOGO_PATH)
             scaled_pixmap = pixmap.scaled(40, 40, Qt.AspectRatioMode.KeepAspectRatio, Qt.TransformationMode.SmoothTransformation)
             icon_label.setPixmap(scaled_pixmap)
         else:


### PR DESCRIPTION
## Summary
- Resolve logo path issues by adding a resource helper and central LOGO_PATH constant
- Replace hard-coded logo references with shared constant across client modules
- Include logo image in PyInstaller spec to display icon in executable

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b03c82b2f0833187cd954479e2a2e9