### PR TITLE
Fix missing application icon after build

### DIFF
--- a/ShippingClient/core/config.py
+++ b/ShippingClient/core/config.py
@@ -44,4 +44,8 @@ def resource_path(relative_path: str) -> str:
     return os.path.join(BASE_DIR, relative_path)
 
 
+# Ruta al logo en formato PNG para usos dentro de la UI (QPixmap)
 LOGO_PATH = resource_path("assets/images/logo.png")
+
+# Ruta al icono en formato ICO para iconos de ventana/aplicación
+ICON_PATH = resource_path("icon.ico")

--- a/ShippingClient/main_client.py
+++ b/ShippingClient/main_client.py
@@ -6,12 +6,12 @@ from PyQt6.QtGui import QFont, QIcon
 
 # Imports locales
 from ui.login_dialog import ModernLoginDialog
-from core.config import MODERN_FONT, FONT_SIZE, LOGO_PATH
+from core.config import MODERN_FONT, FONT_SIZE, ICON_PATH
 
 def main():
     app = QApplication(sys.argv)
-    if os.path.exists(LOGO_PATH):
-        app.setWindowIcon(QIcon(LOGO_PATH))
+    if os.path.exists(ICON_PATH):
+        app.setWindowIcon(QIcon(ICON_PATH))
 
     # Configurar fuente del sistema
     font = QFont(MODERN_FONT, FONT_SIZE)

--- a/ShippingClient/main_client.spec
+++ b/ShippingClient/main_client.spec
@@ -5,7 +5,10 @@ a = Analysis(
     ['main_client.py'],
     pathex=[],
     binaries=[],
-    datas=[('assets/images/logo.png', 'assets/images')],
+    datas=[
+        ('assets/images/logo.png', 'assets/images'),
+        ('icon.ico', '.'),
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/ShippingClient/ui/login_dialog.py
+++ b/ShippingClient/ui/login_dialog.py
@@ -24,15 +24,15 @@ from core.config import (
     LOGIN_HEIGHT,
     MODERN_FONT,
     CONNECTION_RETRY_INTERVAL,
-    LOGO_PATH,
+    ICON_PATH,
 )
 
 class ModernLoginDialog(QDialog):
     def __init__(self):
         super().__init__()
         self.setWindowTitle("Shipping Schedule")
-        if os.path.exists(LOGO_PATH):
-            self.setWindowIcon(QIcon(LOGO_PATH))
+        if os.path.exists(ICON_PATH):
+            self.setWindowIcon(QIcon(ICON_PATH))
         self.setMinimumSize(600, 600)
         self.setModal(True)
 

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -48,6 +48,7 @@ from core.config import (
     WINDOW_HEIGHT,
     MODERN_FONT,
     LOGO_PATH,
+    ICON_PATH,
 )
 
 class ShipmentLoader(QThread):
@@ -148,8 +149,8 @@ class ModernShippingMainWindow(QMainWindow):
         print(f"Inicializando ventana principal para usuario: {user_info['username']}")
         
         self.setWindowTitle("Shipping Schedule")
-        if os.path.exists(LOGO_PATH):
-            self.setWindowIcon(QIcon(LOGO_PATH))
+        if os.path.exists(ICON_PATH):
+            self.setWindowIcon(QIcon(ICON_PATH))
         self.setGeometry(100, 100, WINDOW_WIDTH, WINDOW_HEIGHT)
         self.showMaximized()
         try:


### PR DESCRIPTION
## Summary
- Add dedicated ICON_PATH for window icons
- Use ICO path in main client and dialogs
- Include icon resource in PyInstaller spec

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b04177eabc8331b35a04ab238f4d6e