### PR TITLE
Increase table header font size

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -530,7 +530,7 @@ class ModernShippingMainWindow(QMainWindow):
         border-bottom: 2px solid #E5E7EB;
         border-right: 1px solid #E5E7EB;
         font-weight: 600;
-        font-size: 11px;
+        font-size: 13px;
         text-transform: uppercase;
     }}
         """)

--- a/ShippingClient/ui/user_dialog.py
+++ b/ShippingClient/ui/user_dialog.py
@@ -137,6 +137,8 @@ class UserManagementDialog(QDialog):
         padding: 8px 4px;
         border: none;
         border-right: 1px solid #D1D5DB;
+        font-size: 13px;
+        font-weight: 600;
     }
         """)
         layout.addWidget(self.table)


### PR DESCRIPTION
## Summary
- Increase table header text size in main window for improved readability
- Apply larger, bolded header styling in user management dialog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e94cfe4483318b86afb89ae75b69