### PR TITLE
Configure Alembic and enhance initial migration

### DIFF
--- a/ShippingServer/alembic.ini
+++ b/ShippingServer/alembic.ini
@@ -1,0 +1,48 @@
+[alembic]
+script_location = migrations
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(hour).2d%%(minute).2d_%%(rev)s_%%(slug)s
+timezone = UTC
+truncate_slug_length = 40
+revision_environment = false
+sourceless = false
+version_locations = %(here)s/migrations/versions
+version_path_separator = :
+output_encoding = utf-8
+
+sqlalchemy.url = postgresql://postgres:Gundcab@localhost:5432/shipping_db
+
+[post_write_hooks]
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/ShippingServer/migrations/001_add_versioning.py
+++ b/ShippingServer/migrations/001_add_versioning.py
@@ -1,35 +1,55 @@
-"""
-Migration: Add versioning and integrity fields
-Date: 2024-12-20
-Description: Adds version control and last_modified_by fields to shipments table
-"""
+"""Add versioning and integrity fields
 
+Revision ID: 001
+Revises: 
+Create Date: 2024-12-20 10:00:00.000000
+
+"""
 from alembic import op
 import sqlalchemy as sa
 from datetime import datetime
 
+# revision identifiers
+revision = '001'
+down_revision = None
+branch_labels = None
+depends_on = None
 
-def upgrade():
-    # Agregar nuevas columnas
+def upgrade() -> None:
+    # Agregar columna de versión con valor por defecto
     op.add_column('shipments', sa.Column('version', sa.Integer(), nullable=False, server_default='1'))
+    
+    # Agregar columna last_modified_by
     op.add_column('shipments', sa.Column('last_modified_by', sa.Integer(), nullable=True))
-
-    # Agregar foreign key constraint
+    
+    # Crear foreign key constraint
     op.create_foreign_key(
         'fk_shipments_last_modified_by',
         'shipments', 'users',
         ['last_modified_by'], ['id']
     )
-
-    # Actualizar registros existentes
+    
+    # Actualizar registros existentes para tener last_modified_by
     op.execute("""
         UPDATE shipments 
         SET last_modified_by = created_by, version = 1 
-        WHERE version IS NULL OR last_modified_by IS NULL
+        WHERE last_modified_by IS NULL
     """)
+    
+    # Crear índices para optimización
+    op.create_index('ix_shipment_version', 'shipments', ['version'])
+    op.create_index('ix_shipment_id_version', 'shipments', ['id', 'version'])
+    op.create_index('ix_shipment_last_modified', 'shipments', ['last_modified_by'])
 
-
-def downgrade():
+def downgrade() -> None:
+    # Remover índices
+    op.drop_index('ix_shipment_last_modified', table_name='shipments')
+    op.drop_index('ix_shipment_id_version', table_name='shipments')
+    op.drop_index('ix_shipment_version', table_name='shipments')
+    
+    # Remover foreign key constraint
     op.drop_constraint('fk_shipments_last_modified_by', 'shipments', type_='foreignkey')
+    
+    # Remover columnas
     op.drop_column('shipments', 'last_modified_by')
     op.drop_column('shipments', 'version')

--- a/ShippingServer/migrations/env.py
+++ b/ShippingServer/migrations/env.py
@@ -1,0 +1,53 @@
+import logging
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# Import your models
+from models import Base
+
+# this is the Alembic Config object
+config = context.config
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()


### PR DESCRIPTION
## Summary
- add Alembic configuration and logging setup
- implement Alembic env script for online and offline runs
- expand initial migration with versioning and indexes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6da1a79048331800038b49bd4a782