### PR TITLE
Allow duplicate job numbers

### DIFF
--- a/ShippingServer/models.py
+++ b/ShippingServer/models.py
@@ -26,8 +26,8 @@ class Shipment(Base):
 
     # Índices optimizados para integridad y performance
     __table_args__ = (
-        # Índice único compuesto para prevenir duplicados
-        Index('ix_shipment_job_number_unique', 'job_number', unique=True),
+        # Índice para performance (sin restricción única)
+        Index('ix_shipment_job_number', 'job_number'),
         
         # Índices para control de concurrencia
         Index('ix_shipment_id_version', 'id', 'version'),
@@ -40,7 +40,7 @@ class Shipment(Base):
     )
     
     id = Column(Integer, primary_key=True, index=True)
-    job_number = Column(String(20), unique=True, index=True, nullable=False)
+    job_number = Column(String(20), index=True, nullable=False)
     job_name = Column(String(200), nullable=False)
     week = Column(String(20))
     description = Column(Text)


### PR DESCRIPTION
## Summary
- remove unique index and constraint on shipment job numbers
- replace unique number generation with simple cleaning

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6db96ae2c8331966a7a25bafc3d52