### PR TITLE
Handle two-digit years correctly in date editor

### DIFF
--- a/ShippingClient/ui/date_delegate.py
+++ b/ShippingClient/ui/date_delegate.py
@@ -46,9 +46,12 @@ class DateDelegate(QStyledItemDelegate):
     def setEditorData(self, editor, index):
         text = index.data(Qt.ItemDataRole.EditRole)
         if text:
-            date = QDate.fromString(text, "MM/dd/yy")
+            date = QDate.fromString(text, "MM/dd/yyyy")
             if not date.isValid():
-                date = QDate.fromString(text, "MM/dd/yyyy")
+                date = QDate.fromString(text, "MM/dd/yy")
+                if date.isValid() and date.year() < 2000:
+                    # QDate assumes 1900s for two-digit years; shift to 2000s
+                    date = date.addYears(100)
             if date.isValid():
                 editor.setDate(date)
             else:


### PR DESCRIPTION
## Summary
- adjust date parsing so two-digit years are interpreted in the 2000s

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2433fd88331997cf79b0367f60b