### PR TITLE
Include version in shipment responses

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -98,7 +98,9 @@ class ShipmentResponse(BaseModel):
     invoice_number: str
     shipping_notes: str
     created_by: int
-    
+    version: int
+    last_modified_by: int | None = None
+
     class Config:
         from_attributes = True
 


### PR DESCRIPTION
## Summary
- expose shipment `version` and `last_modified_by` in server responses to avoid optimistic-locking conflicts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b73d81d72083319613d3b565dfa504