### PR TITLE
Remove blocking connection timer from login dialog

### DIFF
--- a/ShippingClient/core/config.py
+++ b/ShippingClient/core/config.py
@@ -26,7 +26,7 @@ LOGIN_HEIGHT = 380
 
 # Timeouts
 REQUEST_TIMEOUT = 10
-CONNECTION_RETRY_INTERVAL = 5000  # 5 segundos
+# CONNECTION_RETRY_INTERVAL = 5000  # 5 segundos
 
 # Estilos
 # Fuente principal para la interfaz. Se puede cambiar para ajustar el estilo


### PR DESCRIPTION
## Summary
- perform server connectivity check once at login dialog startup instead of using a periodic QTimer
- add fast `check_server_connection_once` with short timeout to avoid UI freezes
- comment out unused `CONNECTION_RETRY_INTERVAL` constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e8e8f23c833191879d7624db127e