### PR TITLE
Persist shipment cell colors by ID and field

### DIFF
--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -24,12 +24,12 @@ class SettingsManager:
         self._settings.setValue("ws_url", url)
 
     def save_cell_colors(self, table_name: str, colors: dict[tuple[int, int], str]):
-        """Persist background colors for table cells."""
+        """DEPRECATED: persist colors by (row, column) for legacy support."""
         serialized = {f"{r},{c}": color for (r, c), color in colors.items()}
         self._settings.setValue(f"{table_name}_cell_colors", json.dumps(serialized))
 
     def load_cell_colors(self, table_name: str) -> dict[tuple[int, int], str]:
-        """Retrieve stored background colors for table cells."""
+        """DEPRECATED: retrieve colors stored by (row, column)."""
         data = self._settings.value(f"{table_name}_cell_colors", "{}")
         try:
             raw = json.loads(data)
@@ -40,6 +40,27 @@ class SettingsManager:
             try:
                 r_str, c_str = key.split(",")
                 result[(int(r_str), int(c_str))] = color
+            except Exception:
+                continue
+        return result
+
+    def save_shipment_colors(self, table_name: str, colors: dict[tuple[int, str], str]):
+        """Persist background colors for shipment cells by (shipment_id, field_name)."""
+        serialized = {f"{sid},{field}": color for (sid, field), color in colors.items()}
+        self._settings.setValue(f"{table_name}_shipment_colors", json.dumps(serialized))
+
+    def load_shipment_colors(self, table_name: str) -> dict[tuple[int, str], str]:
+        """Retrieve stored background colors for shipment cells."""
+        data = self._settings.value(f"{table_name}_shipment_colors", "{}")
+        try:
+            raw = json.loads(data)
+        except Exception:
+            return {}
+        result: dict[tuple[int, str], str] = {}
+        for key, color in raw.items():
+            try:
+                sid_str, field = key.split(",", 1)
+                result[(int(sid_str), field)] = color
             except Exception:
                 continue
         return result


### PR DESCRIPTION
## Summary
- Store cell highlight colors keyed by shipment ID and field name
- Track and restore shipment cell colors in main window
- Save shipment color data on close alongside column widths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bebc3d60888331bf8dcb77daf49417