### PR TITLE
Fix date filter dialog tri-state flags for PyQt6

### DIFF
--- a/ShippingClient/ui/date_filter_dialog.py
+++ b/ShippingClient/ui/date_filter_dialog.py
@@ -80,17 +80,24 @@ class DateFilterDialog(QDialog):
         for year in sorted(dates_by_year.keys(), reverse=True):
             year_item = QTreeWidgetItem(self.tree)
             year_item.setText(0, str(year))
-            year_item.setFlags(year_item.flags() | Qt.ItemFlag.ItemIsTristate | Qt.ItemFlag.ItemIsUserCheckable)
+            year_item.setFlags(
+                year_item.flags() | Qt.ItemFlag.ItemIsAutoTristate | Qt.ItemFlag.ItemIsUserCheckable
+            )
 
             for month in sorted(dates_by_year[year].keys(), reverse=True):
                 month_item = QTreeWidgetItem(year_item)
                 month_item.setText(0, date(year, month, 1).strftime("%B"))
-                month_item.setFlags(month_item.flags() | Qt.ItemFlag.ItemIsTristate | Qt.ItemFlag.ItemIsUserCheckable)
+                month_item.setFlags(
+                    month_item.flags() | Qt.ItemFlag.ItemIsAutoTristate | Qt.ItemFlag.ItemIsUserCheckable
+                )
 
                 for dt in sorted(dates_by_year[year][month], reverse=True):
                     day_item = QTreeWidgetItem(month_item)
                     day_item.setText(0, dt.strftime("%b %d, %Y"))
-                    day_item.setFlags((day_item.flags() | Qt.ItemFlag.ItemIsUserCheckable) & ~Qt.ItemFlag.ItemIsTristate)
+                    day_item.setFlags(
+                        (day_item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+                        & ~Qt.ItemFlag.ItemIsAutoTristate
+                    )
                     day_item.setData(0, Qt.ItemDataRole.UserRole, dt)
 
     def _connect_signals(self) -> None:


### PR DESCRIPTION
## Summary
- replace the deprecated ItemIsTristate flag usage with ItemIsAutoTristate for PyQt6
- ensure day entries remove the auto-tristate flag while keeping user checkable behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3b1fdc8a4833186a4062952cac052