### PR TITLE
Implement inline date filter popup in tables

### DIFF
--- a/ShippingClient/ui/date_filter_header.py
+++ b/ShippingClient/ui/date_filter_header.py
@@ -36,10 +36,10 @@ class DateFilterHeader(QHeaderView):
         if logical in self._filter_columns:
             section_rect = self._section_rect(logical)
             if event.button() == Qt.MouseButton.LeftButton:
-                if event.position().x() >= section_rect.right() - self._indicator_width:
-                    self.filter_requested.emit(logical, self.mapToGlobal(section_rect.bottomRight()))
-                    event.accept()
-                    return
+                super().mousePressEvent(event)
+                self.filter_requested.emit(logical, self.mapToGlobal(section_rect.bottomRight()))
+                event.accept()
+                return
             elif event.button() == Qt.MouseButton.RightButton:
                 self.filter_requested.emit(logical, self.mapToGlobal(event.pos()))
                 event.accept()


### PR DESCRIPTION
## Summary
- replace the date filter dialog with an inline popup menu so filters appear directly under the column header
- update the table header interaction to trigger the popup on left-click while preserving the filter indicators
- wire the main window to use the new popup implementation when applying date filters

## Testing
- python -m compileall ShippingClient/ui

------
https://chatgpt.com/codex/tasks/task_e_68e3b37561388331a2318db4b3e33d69