### PR TITLE
Fix shipment filter method signature

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1225,7 +1225,7 @@ class ModernShippingMainWindow(QMainWindow):
 
         # La altura de las filas se ajusta al finalizar el poblado completo
 
-    def apply_filters_to_shipments(self, shipments, _is_active=True):
+    def apply_filters_to_shipments(self, shipments, is_active=True):
         """Aplicar filtros"""
         filtered = shipments
         


### PR DESCRIPTION
## Summary
- update the apply_filters_to_shipments signature to accept the is_active keyword argument used by callers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3bbdc0d0483318f4f3ee5904cb79a