### PR TITLE
Restrict date filter menu to right click and update indicator

### DIFF
--- a/ShippingClient/ui/date_filter_header.py
+++ b/ShippingClient/ui/date_filter_header.py
@@ -33,17 +33,10 @@ class DateFilterHeader(QHeaderView):
 
     def mousePressEvent(self, event):
         logical = self.logicalIndexAt(event.pos())
-        if logical in self._filter_columns:
-            section_rect = self._section_rect(logical)
-            if event.button() == Qt.MouseButton.LeftButton:
-                super().mousePressEvent(event)
-                self.filter_requested.emit(logical, self.mapToGlobal(section_rect.bottomRight()))
-                event.accept()
-                return
-            elif event.button() == Qt.MouseButton.RightButton:
-                self.filter_requested.emit(logical, self.mapToGlobal(event.pos()))
-                event.accept()
-                return
+        if logical in self._filter_columns and event.button() == Qt.MouseButton.RightButton:
+            self.filter_requested.emit(logical, self.mapToGlobal(event.pos()))
+            event.accept()
+            return
         super().mousePressEvent(event)
 
     def paintSection(self, painter: QPainter, rect: QRect, logicalIndex: int) -> None:

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -605,7 +605,7 @@ class ModernShippingMainWindow(QMainWindow):
             return
 
         base_text = base_labels[column]
-        header_item.setText(f"{base_text} (Filtered)" if active else base_text)
+        header_item.setText(f"{base_text} 🔍" if active else base_text)
         header_item.setForeground(QBrush(QColor("#1D4ED8" if active else "#000000")))
 
         if active:


### PR DESCRIPTION
## Summary
- open the date filter popup only from right-click interactions on eligible header sections
- replace the textual "(Filtered)" header suffix with a magnifying glass icon for active filters

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68e3cc8cf7c48331afce1f89d8106676