### PR TITLE
Replace header filter icon with down arrow indicator

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -605,7 +605,7 @@ class ModernShippingMainWindow(QMainWindow):
             return
 
         base_text = base_labels[column]
-        header_item.setText(f"{base_text} 🔍" if active else base_text)
+        header_item.setText(f"{base_text} 🔽" if active else base_text)
         header_item.setForeground(QBrush(QColor("#1D4ED8" if active else "#000000")))
 
         if active:


### PR DESCRIPTION
## Summary
- replace the column header filter indicator icon with a down arrow instead of a magnifying glass

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3f21852cc8331a9cfdd8cfaa4f4d2