### PR TITLE
Improve placeholder legibility

### DIFF
--- a/ShippingClient/ui/widgets.py
+++ b/ShippingClient/ui/widgets.py
@@ -129,12 +129,12 @@ class ModernLineEdit(QLineEdit):
         super().__init__()
         self.setPlaceholderText(placeholder)
         self.setMinimumHeight(40)
-        apply_scaled_font(self)
+        apply_scaled_font(self, offset=2)
         self.apply_professional_style()
 
     def apply_professional_style(self):
         """Aplicar estilo profesional al input"""
-        font_size = max(8, self.font().pointSize() + 3)
+        font_size = max(10, self.font().pointSize() + 4)
         placeholder_font_size = font_size + 2
         self.setStyleSheet(
             f"""


### PR DESCRIPTION
## Summary
- increase the base font scaling used by ModernLineEdit widgets
- bump the styled font sizes so placeholder text is easier to read

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3fd9bd6a0833198ca33231c1513ac