### PR TITLE
Fix Select All checkbox state handling

### DIFF
--- a/ShippingClient/ui/date_filter_dialog.py
+++ b/ShippingClient/ui/date_filter_dialog.py
@@ -178,10 +178,10 @@ class DateFilterPopup(QMenu):
             self._update_parent_states(item)
         self._update_select_all_state()
 
-    def _on_select_all_state_changed(self, state: int) -> None:
-        if state == int(Qt.CheckState.PartiallyChecked):
-            return
+    def _on_select_all_state_changed(self, state: Qt.CheckState | int) -> None:
         qt_state = Qt.CheckState(state)
+        if qt_state == Qt.CheckState.PartiallyChecked:
+            return
         for i in range(self.tree.topLevelItemCount()):
             item = self.tree.topLevelItem(i)
             item.setCheckState(0, qt_state)


### PR DESCRIPTION
## Summary
- normalize the Select All state value using Qt.CheckState before comparisons
- prevent crashes when the checkbox emits a PartiallyChecked state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52123b3e08331b4872dce7a416621