### PR TITLE
Autoajustar altura de filas en tablas para evitar recorte de texto

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -441,7 +441,7 @@ class StatusChipDelegate(QStyledItemDelegate):
 class WrapAnywhereDelegate(QStyledItemDelegate):
     """Custom delegate that allows long text chunks to wrap in table cells."""
 
-    _PADDING = 8
+    _PADDING = 12
     _MIN_HINT_WIDTH = 180
     _SELECTED_TEXT_COLOR = QColor("#0F2A57")
 
@@ -465,9 +465,9 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
         else:
             painter.setPen(opt.palette.text().color())
         painter.drawText(
-            text_rect.adjusted(2, 0, -2, 0),
+            text_rect.adjusted(2, 2, -2, -2),
             Qt.AlignmentFlag.AlignLeft
-            | Qt.AlignmentFlag.AlignVCenter
+            | Qt.AlignmentFlag.AlignTop
             | Qt.TextFlag.TextWordWrap
             | Qt.TextFlag.TextWrapAnywhere,
             text,
@@ -492,6 +492,7 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
 
 
 class ModernShippingMainWindow(QMainWindow):
+    _ROW_EXTRA_HEIGHT = 6
     DEFAULT_TABLE_COLUMNS = [
         "Job Number",
         "Job Name",
@@ -2807,9 +2808,10 @@ class ModernShippingMainWindow(QMainWindow):
         table_font_size = max(14, base_size + 4)
         metrics = QFontMetrics(QFont(MODERN_FONT, table_font_size))
 
-        default_height = max(46, int(metrics.lineSpacing() * 1.72))
+        default_height = max(46, int(metrics.lineSpacing() * 1.72)) + self._ROW_EXTRA_HEIGHT
 
-        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
+        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        vertical_header.setMinimumSectionSize(default_height)
         vertical_header.setDefaultSectionSize(default_height)
 
     def _get_column_content_width(self, table, column: int) -> int:
@@ -2851,10 +2853,13 @@ class ModernShippingMainWindow(QMainWindow):
         bottom_row = table.rowAt(table.viewport().height() - 1)
         if top_row < 0 or bottom_row < 0:
             table.resizeRowsToContents()
+            for row in range(row_count):
+                table.setRowHeight(row, table.rowHeight(row) + self._ROW_EXTRA_HEIGHT)
             return
 
         for row in range(top_row, min(bottom_row + 1, row_count)):
             table.resizeRowToContents(row)
+            table.setRowHeight(row, table.rowHeight(row) + self._ROW_EXTRA_HEIGHT)
 
     def _refresh_table_item_fonts(self, table):
         """Update table item fonts according to the active preference."""

--- a/ShippingClient/ui/tracking_dialog.py
+++ b/ShippingClient/ui/tracking_dialog.py
@@ -60,6 +60,11 @@ class TrackingDetailsDialog(QDialog):
         events_table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
         events_table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
         events_table.horizontalHeader().setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        events_table.setWordWrap(True)
+        events_table.setTextElideMode(Qt.TextElideMode.ElideNone)
+        events_table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        events_table.verticalHeader().setDefaultSectionSize(40)
+        events_table.verticalHeader().setMinimumSectionSize(40)
         for row, event in enumerate(events):
             events_table.setItem(row, 0, QTableWidgetItem(str(event.get("timestamp") or "—")))
             location = ", ".join(
@@ -75,6 +80,9 @@ class TrackingDetailsDialog(QDialog):
             )
             events_table.setItem(row, 1, QTableWidgetItem(location or "—"))
             events_table.setItem(row, 2, QTableWidgetItem(str(event.get("description") or event.get("eventType") or "—")))
+        events_table.resizeRowsToContents()
+        for row in range(events_table.rowCount()):
+            events_table.setRowHeight(row, events_table.rowHeight(row) + 4)
 
         layout.addWidget(events_table)
 

--- a/ShippingClient/ui/user_dialog.py
+++ b/ShippingClient/ui/user_dialog.py
@@ -180,6 +180,11 @@ class UserManagementWidget(QWidget):
         self.table = QTableWidget(0, 4)
         self.table.setHorizontalHeaderLabels(["ID", "Username", "Email", "Role"])
         self.table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        self.table.setWordWrap(True)
+        self.table.setTextElideMode(Qt.TextElideMode.ElideNone)
+        self.table.verticalHeader().setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        self.table.verticalHeader().setDefaultSectionSize(40)
+        self.table.verticalHeader().setMinimumSectionSize(40)
         header_font = max(8, get_base_font_size() + 3)
         self.table.setStyleSheet(
             f"""
@@ -221,6 +226,9 @@ class UserManagementWidget(QWidget):
                     self.table.setItem(row, 1, QTableWidgetItem(user["username"]))
                     self.table.setItem(row, 2, QTableWidgetItem(user["email"]))
                     self.table.setItem(row, 3, QTableWidgetItem(user["role"]))
+                self.table.resizeRowsToContents()
+                for row in range(self.table.rowCount()):
+                    self.table.setRowHeight(row, self.table.rowHeight(row) + 4)
             else:
                 self.show_error(resp.text)
         except Exception as e:


### PR DESCRIPTION
### Motivation
- Algunas celdas con contenido largo se recortaban porque la altura de fila no se ajustaba al texto envuelto, generando UX deficiente en varias tablas de la app.
- Se buscó una solución global que permita el wrapping seguro del texto y que deje un pequeño margen extra por fila para evitar cortes visuales.

### Description
- Modifiqué el delegado `WrapAnywhereDelegate` para aumentar el padding interno (`_PADDING` de `8` a `12`), alinear el texto al tope y usar un recto interno ajustado al pintar, mejorando también el cálculo de `sizeHint` para textos multilínea. (`ShippingClient/ui/main_window.py`)
- Añadí ` _ROW_EXTRA_HEIGHT = 6` en `ModernShippingMainWindow` y cambié `_configure_table_row_metrics` para usar `ResizeToContents` en el `verticalHeader` y fijar `minimum/default` section size incluyendo el margen extra. (`ShippingClient/ui/main_window.py`)
- Actualicé `_refresh_visible_row_heights` para invocar `resizeRowsToContents()`/`resizeRowToContents()` y aplicar el pequeño incremento de altura por fila tras el redimensionado, garantizando recalculos cuando cambian anchos/contenido. (`ShippingClient/ui/main_window.py`)
- Apliqué el mismo enfoque a tablas auxiliares en diálogos: en `UserManagementWidget` y `TrackingDetailsDialog` habilité `setWordWrap(True)`, `setTextElideMode(Qt.TextElideMode.ElideNone)`, puse el `verticalHeader` en `ResizeToContents` con `default/minimum` section sizes y llamé a `resizeRowsToContents()` seguido de un pequeño `setRowHeight(... +4)` para evitar cortes. (`ShippingClient/ui/user_dialog.py`, `ShippingClient/ui/tracking_dialog.py`)

### Testing
- Compilé los módulos modificados con `python -m compileall ShippingClient/ui/main_window.py ShippingClient/ui/user_dialog.py ShippingClient/ui/tracking_dialog.py` y la compilación fue exitosa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e21a8cd618833190adbcde9f3e6b67)