### PR TITLE
Add Die # Database (sills_die_database) with API and UI integration

### DIFF
--- a/ShippingClient/core/api_client.py
+++ b/ShippingClient/core/api_client.py
@@ -254,3 +254,15 @@ class RobustApiClient:
         if end_date:
             params["end_date"] = end_date
         return self.get("/sills-logs", params=params)
+
+    def get_sill_dies(self) -> ApiResponse:
+        return self.get("/sills/dies")
+
+    def create_sill_die(self, data: Dict) -> ApiResponse:
+        return self.post("/sills/dies", data=data)
+
+    def update_sill_die(self, die_id: int, data: Dict) -> ApiResponse:
+        return self.put(f"/sills/dies/{die_id}", data=data)
+
+    def delete_sill_die(self, die_id: int) -> ApiResponse:
+        return self.delete(f"/sills/dies/{die_id}")

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -40,6 +40,7 @@ from PyQt6.QtWidgets import (
     QSizePolicy,
     QLineEdit,
     QComboBox,
+    QCompleter,
     QDateEdit,
     QStyleOptionViewItem,
     QStyledItemDelegate,
@@ -166,11 +167,22 @@ class SillDialog(QDialog):
         ("week_to_print", "Week to Print"),
     ]
 
-    def __init__(self, parent: Optional[QWidget] = None, sill_data: Optional[dict] = None):
+    def __init__(
+        self,
+        parent: Optional[QWidget] = None,
+        sill_data: Optional[dict] = None,
+        die_database: Optional[list[dict]] = None,
+    ):
         super().__init__(parent)
         self.setWindowTitle("Sill")
         self.setMinimumWidth(520)
         self._edit_data = sill_data or {}
+        self._die_database = die_database or []
+        self._die_lookup = {
+            str(item.get("die_number", "")).strip().lower(): item
+            for item in self._die_database
+            if str(item.get("die_number", "")).strip()
+        }
         self.inputs: Dict[str, QWidget] = {}
 
         layout = QVBoxLayout(self)
@@ -183,11 +195,14 @@ class SillDialog(QDialog):
                 input_widget.addItems(["NS", "SS", "SS316", "BR", "AL"])
             elif key == "type":
                 input_widget = QComboBox()
-                input_widget.addItems(["Hatch", "Car"])
+                input_widget.addItems(["", "Hatch", "Car", "Extension"])
             elif key == "week_to_print":
                 input_widget = QDateEdit()
                 input_widget.setCalendarPopup(True)
                 input_widget.setDisplayFormat("yyyy-MM-dd")
+            elif key == "speed":
+                input_widget = QComboBox()
+                input_widget.addItems(["", "0", "1", "2", "3"])
             else:
                 input_widget = QLineEdit()
             value = str(self._edit_data.get(key, ""))
@@ -200,6 +215,116 @@ class SillDialog(QDialog):
                 input_widget.setDate(parsed_date if parsed_date.isValid() else QDate.currentDate())
             else:
                 input_widget.setText(value)
+            form.addRow(QLabel(label), input_widget)
+            self.inputs[key] = input_widget
+
+        self._configure_die_autofill()
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Save | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_payload(self) -> dict:
+        payload = {}
+        for key, _ in self.FIELDS:
+            widget = self.inputs[key]
+            if isinstance(widget, QComboBox):
+                payload[key] = widget.currentText().strip()
+            elif isinstance(widget, QDateEdit):
+                payload[key] = widget.date().toString("yyyy-MM-dd")
+            else:
+                payload[key] = widget.text().strip()
+        return payload
+
+    def _configure_die_autofill(self) -> None:
+        die_widget = self.inputs.get("die_number")
+        if not isinstance(die_widget, QLineEdit) or not self._die_database:
+            return
+
+        values = sorted({str(item.get("die_number", "")).strip() for item in self._die_database if item.get("die_number")})
+        completer = QCompleter(values, self)
+        completer.setCaseSensitivity(Qt.CaseSensitivity.CaseInsensitive)
+        completer.setFilterMode(Qt.MatchFlag.MatchContains)
+        completer.activated.connect(self._apply_die_data)
+        die_widget.setCompleter(completer)
+        die_widget.editingFinished.connect(lambda: self._apply_die_data(die_widget.text()))
+
+    def _apply_die_data(self, die_number: str) -> None:
+        lookup_key = (die_number or "").strip().lower()
+        if not lookup_key:
+            return
+
+        die_data = self._die_lookup.get(lookup_key)
+        if not die_data:
+            return
+
+        text_fields = ("type", "width")
+        for field_name in text_fields:
+            widget = self.inputs.get(field_name)
+            if isinstance(widget, QLineEdit):
+                widget.setText(str(die_data.get(field_name, "") or ""))
+            elif isinstance(widget, QComboBox):
+                value = str(die_data.get(field_name, "") or "")
+                idx = widget.findText(value)
+                if idx >= 0:
+                    widget.setCurrentIndex(idx)
+
+        speed_widget = self.inputs.get("speed")
+        speed_value = str(die_data.get("speed", "") or "")
+        if isinstance(speed_widget, QComboBox):
+            idx = speed_widget.findText(speed_value)
+            if idx >= 0:
+                speed_widget.setCurrentIndex(idx)
+
+        notes_widget = self.inputs.get("notes")
+        if isinstance(notes_widget, QLineEdit) and not notes_widget.text().strip():
+            notes_widget.setText(str(die_data.get("notes", "") or ""))
+
+
+class SillDieDialog(QDialog):
+    FIELDS = [
+        ("die_number", "Die #"),
+        ("type", "Type"),
+        ("speed", "Speed"),
+        ("width", "Width"),
+        ("supplier", "Supplier"),
+        ("notes", "Notes"),
+        ("vendor_drawing", "Vendor Drawing"),
+    ]
+
+    def __init__(self, parent: Optional[QWidget] = None, die_data: Optional[dict] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Die # Database")
+        self.setMinimumWidth(520)
+        self._edit_data = die_data or {}
+        self.inputs: Dict[str, QWidget] = {}
+
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        form.setSpacing(10)
+
+        for key, label in self.FIELDS:
+            if key == "type":
+                input_widget = QComboBox()
+                input_widget.addItems(["Car", "Hatch", "Extension"])
+            elif key == "speed":
+                input_widget = QComboBox()
+                input_widget.addItems(["0", "1", "2", "3"])
+            else:
+                input_widget = QLineEdit()
+
+            value = str(self._edit_data.get(key, ""))
+            if isinstance(input_widget, QComboBox):
+                idx = input_widget.findText(value)
+                if idx >= 0:
+                    input_widget.setCurrentIndex(idx)
+            else:
+                input_widget.setText(value)
+
             form.addRow(QLabel(label), input_widget)
             self.inputs[key] = input_widget
 
@@ -218,8 +343,6 @@ class SillDialog(QDialog):
             widget = self.inputs[key]
             if isinstance(widget, QComboBox):
                 payload[key] = widget.currentText().strip()
-            elif isinstance(widget, QDateEdit):
-                payload[key] = widget.date().toString("yyyy-MM-dd")
             else:
                 payload[key] = widget.text().strip()
         return payload
@@ -638,6 +761,7 @@ class ModernShippingMainWindow(QMainWindow):
         self._pending_shipment_reload = False
         self.shipping_logs = []
         self.sills = []
+        self.sill_dies = []
         self.sills_logs = []
 
         # Mapa de columna a campo de API para ediciones inline
@@ -1733,8 +1857,45 @@ class ModernShippingMainWindow(QMainWindow):
         logs_layout.addLayout(log_filters)
         logs_layout.addWidget(self.sills_logs_table)
 
+        die_page = QWidget()
+        die_layout = QVBoxLayout(die_page)
+        die_layout.setContentsMargins(0, 0, 0, 0)
+        die_layout.setSpacing(SPACE_12)
+
+        die_actions_layout = QHBoxLayout()
+        die_actions_layout.setContentsMargins(0, 0, 0, 0)
+        die_actions_layout.setSpacing(10)
+        self.sills_die_add_btn = ModernButton("Add Die", "primary", min_height=30, min_width=100, padding=(4, 10))
+        self.sills_die_edit_btn = ModernButton("Edit Selected", "outline", min_height=30, min_width=120, padding=(4, 10))
+        self.sills_die_delete_btn = ModernButton("Delete Selected", "danger-outline", min_height=30, min_width=120, padding=(4, 10))
+        self.sills_die_refresh_btn = ModernButton("Refresh", "outline", min_height=30, min_width=88, padding=(4, 10))
+        die_actions_layout.addWidget(self.sills_die_add_btn)
+        die_actions_layout.addWidget(self.sills_die_edit_btn)
+        die_actions_layout.addWidget(self.sills_die_delete_btn)
+        die_actions_layout.addStretch(1)
+        die_actions_layout.addWidget(self.sills_die_refresh_btn)
+
+        self.sills_die_table = QTableWidget()
+        self.sills_die_table.setColumnCount(7)
+        self.sills_die_table.setHorizontalHeaderLabels(
+            ["Die #", "Type", "Speed", "Width", "Supplier", "Notes", "Vendor Drawing"]
+        )
+        self.sills_die_table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        self.sills_die_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.sills_die_table.verticalHeader().setVisible(False)
+        self.sills_die_table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Interactive)
+        self.sills_die_table.setWordWrap(True)
+        self.sills_die_table.setItemDelegateForColumn(5, self.wrap_anywhere_delegate)  # Notes
+        self.sills_die_table.setItemDelegateForColumn(6, self.wrap_anywhere_delegate)  # Vendor Drawing
+        self._apply_table_style(self.sills_die_table)
+        self._configure_table_row_metrics(self.sills_die_table)
+
+        die_layout.addLayout(die_actions_layout)
+        die_layout.addWidget(self.sills_die_table)
+
         tabs.addTab(sheet_page, "Sills Sheet")
         tabs.addTab(logs_page, "Activity Log")
+        tabs.addTab(die_page, "Die # Database")
         page_layout.addWidget(tabs)
 
         self.sills_add_btn.clicked.connect(self.open_add_sill_dialog)
@@ -1744,9 +1905,15 @@ class ModernShippingMainWindow(QMainWindow):
         self.sills_print_btn.clicked.connect(self.print_sills_sheet_to_pdf)
         self.sills_logs_refresh_btn.clicked.connect(self.load_sills_logs)
         self.sills_table.itemDoubleClicked.connect(lambda _: self.open_edit_sill_dialog())
-        tabs.currentChanged.connect(lambda idx: self.load_sills_logs() if idx == 1 else self.load_sills())
+        self.sills_die_add_btn.clicked.connect(self.open_add_sill_die_dialog)
+        self.sills_die_edit_btn.clicked.connect(self.open_edit_sill_die_dialog)
+        self.sills_die_delete_btn.clicked.connect(self.delete_sill_die)
+        self.sills_die_refresh_btn.clicked.connect(self.load_sill_dies)
+        self.sills_die_table.itemDoubleClicked.connect(lambda _: self.open_edit_sill_die_dialog())
+        tabs.currentChanged.connect(self._on_sills_tab_changed)
 
         self.load_sills()
+        self.load_sill_dies()
         return page
 
     def load_sills(self):
@@ -1802,6 +1969,33 @@ class ModernShippingMainWindow(QMainWindow):
         self.sills_logs_table.resizeColumnsToContents()
         self.sills_logs_table.resizeRowsToContents()
 
+    def _on_sills_tab_changed(self, index: int):
+        if index == 1:
+            self.load_sills_logs()
+        elif index == 2:
+            self.load_sill_dies()
+        else:
+            self.load_sills()
+
+    def load_sill_dies(self):
+        response = self.api_client.get_sill_dies()
+        if not response.is_success():
+            self.show_error(response.get_error() or "Failed to load die database.")
+            return
+        self.sill_dies = response.get_data() or []
+        self.populate_sill_dies_table()
+
+    def populate_sill_dies_table(self):
+        rows = self.sill_dies or []
+        self.sills_die_table.setRowCount(len(rows))
+        fields = ["die_number", "type", "speed", "width", "supplier", "notes", "vendor_drawing"]
+        for row_index, item in enumerate(rows):
+            for col_index, field in enumerate(fields):
+                value = "" if item.get(field) is None else str(item.get(field))
+                self.sills_die_table.setItem(row_index, col_index, QTableWidgetItem(value))
+        self.sills_die_table.resizeColumnsToContents()
+        self.sills_die_table.resizeRowsToContents()
+
     def _selected_sill(self) -> Optional[dict]:
         row = self.sills_table.currentRow()
         if row < 0:
@@ -1810,11 +2004,19 @@ class ModernShippingMainWindow(QMainWindow):
             return None
         return self.sills[row]
 
+    def _selected_sill_die(self) -> Optional[dict]:
+        row = self.sills_die_table.currentRow()
+        if row < 0:
+            return None
+        if row >= len(self.sill_dies):
+            return None
+        return self.sill_dies[row]
+
     def open_add_sill_dialog(self):
         if self.read_only:
             self.show_error("You only have read permissions.")
             return
-        dialog = SillDialog(self)
+        dialog = SillDialog(self, die_database=self.sill_dies)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             response = self.api_client.create_sill(dialog.get_payload())
             if response.is_success():
@@ -1831,7 +2033,7 @@ class ModernShippingMainWindow(QMainWindow):
         if not sill:
             self.show_error("Select a sill first.")
             return
-        dialog = SillDialog(self, sill_data=sill)
+        dialog = SillDialog(self, sill_data=sill, die_database=self.sill_dies)
         if dialog.exec() == QDialog.DialogCode.Accepted:
             response = self.api_client.update_sill(int(sill["id"]), dialog.get_payload())
             if response.is_success():
@@ -1857,6 +2059,56 @@ class ModernShippingMainWindow(QMainWindow):
             self.load_sills_logs()
         else:
             self.show_error(response.get_error() or "Failed to delete sill.")
+
+    def open_add_sill_die_dialog(self):
+        if self.read_only:
+            self.show_error("You only have read permissions.")
+            return
+        dialog = SillDieDialog(self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            response = self.api_client.create_sill_die(dialog.get_payload())
+            if response.is_success():
+                self.load_sill_dies()
+            else:
+                self.show_error(response.get_error() or "Failed to create die.")
+
+    def open_edit_sill_die_dialog(self):
+        if self.read_only:
+            self.show_error("You only have read permissions.")
+            return
+        die_data = self._selected_sill_die()
+        if not die_data:
+            self.show_error("Select a die first.")
+            return
+        dialog = SillDieDialog(self, die_data=die_data)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            response = self.api_client.update_sill_die(int(die_data["id"]), dialog.get_payload())
+            if response.is_success():
+                self.load_sill_dies()
+            else:
+                self.show_error(response.get_error() or "Failed to update die.")
+
+    def delete_sill_die(self):
+        if self.read_only:
+            self.show_error("You only have read permissions.")
+            return
+        die_data = self._selected_sill_die()
+        if not die_data:
+            self.show_error("Select a die first.")
+            return
+        answer = QMessageBox.question(
+            self,
+            "Delete Die",
+            f"Delete die {die_data.get('die_number', '')}?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+        )
+        if answer != QMessageBox.StandardButton.Yes:
+            return
+        response = self.api_client.delete_sill_die(int(die_data["id"]))
+        if response.is_success():
+            self.load_sill_dies()
+        else:
+            self.show_error(response.get_error() or "Failed to delete die.")
     
     def setup_professional_table(self, table, module_config: TabModuleConfig):
         """Configurar tabla con estilo profesional y restaurar ancho de columnas"""

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm.exc import StaleDataError
 
 # Imports locales
 from database import get_db, create_tables, create_admin_user
-from models import User, Shipment, AuditLog, ShippingLog, AppConnectionSettings, Sill, SillLog
+from models import User, Shipment, AuditLog, ShippingLog, AppConnectionSettings, Sill, SillLog, SillDieDatabase
 from auth import authenticate_user, create_access_token, get_current_user, get_current_admin_user, Token, UserLogin, UserCreate
 from pydantic import BaseModel
 from fedex_service import FedExService
@@ -228,6 +228,40 @@ class SillLogResponse(BaseModel):
     old_value: str
     new_value: str
     changed_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class SillDieCreate(BaseModel):
+    die_number: str
+    type: str = ""
+    speed: str = ""
+    width: str = ""
+    supplier: str = ""
+    notes: str = ""
+    vendor_drawing: str = ""
+
+
+class SillDieUpdate(BaseModel):
+    die_number: str | None = None
+    type: str | None = None
+    speed: str | None = None
+    width: str | None = None
+    supplier: str | None = None
+    notes: str | None = None
+    vendor_drawing: str | None = None
+
+
+class SillDieResponse(BaseModel):
+    id: int
+    die_number: str
+    type: str
+    speed: str
+    width: str
+    supplier: str
+    notes: str
+    vendor_drawing: str
 
     class Config:
         from_attributes = True
@@ -1133,6 +1167,104 @@ async def get_sills_logs(
         )
         for log in logs
     ]
+
+
+def _validate_sill_die_payload(payload: dict) -> dict:
+    normalized = {k: _safe_text(v).strip() for k, v in payload.items()}
+    valid_types = {"Car", "Hatch", "Extension"}
+    valid_speeds = {"0", "1", "2", "3"}
+
+    if not normalized.get("die_number"):
+        raise HTTPException(status_code=400, detail="Die number is required")
+    if normalized.get("type") and normalized["type"] not in valid_types:
+        raise HTTPException(status_code=400, detail="Type must be Car, Hatch, or Extension")
+    if normalized.get("speed") and normalized["speed"] not in valid_speeds:
+        raise HTTPException(status_code=400, detail="Speed must be one of: 0, 1, 2, 3")
+    return normalized
+
+
+@app.get("/sills/dies", response_model=List[SillDieResponse])
+async def get_sill_dies(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    return db.query(SillDieDatabase).order_by(SillDieDatabase.die_number.asc()).all()
+
+
+@app.post("/sills/dies", response_model=SillDieResponse)
+async def create_sill_die(
+    die_data: SillDieCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role not in ["write", "admin"]:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    payload = _validate_sill_die_payload(die_data.dict())
+    new_die = SillDieDatabase(
+        **payload,
+        created_by=current_user.id,
+        last_modified_by=current_user.id,
+    )
+    db.add(new_die)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Die number already exists")
+    db.refresh(new_die)
+    return new_die
+
+
+@app.put("/sills/dies/{die_id}", response_model=SillDieResponse)
+async def update_sill_die(
+    die_id: int,
+    die_update: SillDieUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role not in ["write", "admin"]:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    die = db.query(SillDieDatabase).filter(SillDieDatabase.id == die_id).first()
+    if not die:
+        raise HTTPException(status_code=404, detail="Die not found")
+
+    payload = {k: _safe_text(v).strip() for k, v in die_update.dict(exclude_unset=True).items()}
+    if "type" in payload and payload["type"] and payload["type"] not in {"Car", "Hatch", "Extension"}:
+        raise HTTPException(status_code=400, detail="Type must be Car, Hatch, or Extension")
+    if "speed" in payload and payload["speed"] and payload["speed"] not in {"0", "1", "2", "3"}:
+        raise HTTPException(status_code=400, detail="Speed must be one of: 0, 1, 2, 3")
+    if "die_number" in payload and not payload["die_number"]:
+        raise HTTPException(status_code=400, detail="Die number is required")
+
+    for field, value in payload.items():
+        setattr(die, field, value)
+
+    die.last_modified_by = current_user.id
+    die.updated_at = datetime.utcnow()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Die number already exists")
+    db.refresh(die)
+    return die
+
+
+@app.delete("/sills/dies/{die_id}")
+async def delete_sill_die(
+    die_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if current_user.role not in ["write", "admin"]:
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+
+    die = db.query(SillDieDatabase).filter(SillDieDatabase.id == die_id).first()
+    if not die:
+        raise HTTPException(status_code=404, detail="Die not found")
+
+    db.delete(die)
+    db.commit()
+    return {"message": "Die deleted successfully"}
 
 if __name__ == "__main__":
     import uvicorn

--- a/ShippingServer/migrations/versions/008_add_sills_die_database.py
+++ b/ShippingServer/migrations/versions/008_add_sills_die_database.py
@@ -1,0 +1,42 @@
+"""Add sills die database table
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+from alembic import op
+
+
+revision = '008'
+down_revision = '007'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS sills_die_database (
+            id SERIAL PRIMARY KEY,
+            die_number VARCHAR(50) NOT NULL UNIQUE,
+            type VARCHAR(20) NOT NULL DEFAULT '',
+            speed VARCHAR(10) NOT NULL DEFAULT '',
+            width VARCHAR(30) NOT NULL DEFAULT '',
+            supplier VARCHAR(120) NOT NULL DEFAULT '',
+            notes TEXT NOT NULL DEFAULT '',
+            vendor_drawing TEXT NOT NULL DEFAULT '',
+            created_by INTEGER NOT NULL REFERENCES users(id),
+            created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+            last_modified_by INTEGER REFERENCES users(id)
+        )
+        """
+    )
+
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sills_die_database_die_number ON sills_die_database (die_number)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_sills_die_database_die_number")
+    op.execute("DROP TABLE IF EXISTS sills_die_database")

--- a/ShippingServer/models.py
+++ b/ShippingServer/models.py
@@ -311,6 +311,30 @@ class SillLog(Base):
     sill = relationship("Sill")
 
 
+class SillDieDatabase(Base):
+    __tablename__ = "sills_die_database"
+
+    __table_args__ = (
+        Index("ix_sills_die_database_die_number", "die_number"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    die_number = Column(String(50), nullable=False, unique=True)
+    type = Column(String(20), nullable=False, default="", server_default=text("''"))
+    speed = Column(String(10), nullable=False, default="", server_default=text("''"))
+    width = Column(String(30), nullable=False, default="", server_default=text("''"))
+    supplier = Column(String(120), nullable=False, default="", server_default=text("''"))
+    notes = Column(Text, nullable=False, default="", server_default=text("''"))
+    vendor_drawing = Column(Text, nullable=False, default="", server_default=text("''"))
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    last_modified_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    creator = relationship("User", foreign_keys=[created_by])
+    last_modifier = relationship("User", foreign_keys=[last_modified_by])
+
+
 class AppConnectionSettings(Base):
     __tablename__ = "app_connection_settings"
 


### PR DESCRIPTION
### Motivation
- Añadir un catálogo central de Dies para el módulo de Sills para poder reusar datos (Type, Speed, Width, Supplier, Notes, Vendor drawing) y acelerar la entrada de datos en el Sills Sheet mediante autocompletado y autocompletado de campos relacionados.

### Description
- Agregada migración Alembic `008_add_sills_die_database.py` que crea la tabla `sills_die_database` con índice por `die_number` y `downgrade()` para revertirla.
- Nuevo modelo SQLAlchemy `SillDieDatabase` en `ShippingServer/models.py` que refleja los campos solicitados y referencia a `users` para auditoría de creación/modificación.
- Nuevos esquemas y endpoints CRUD en `ShippingServer/main.py` bajo `/sills/dies` (`GET`, `POST`, `PUT`, `DELETE`) con validaciones para `type` (`Car`, `Hatch`, `Extension`), `speed` (`0`–`3`) y unicidad de `die_number`.
- Extensión del cliente de escritorio `RobustApiClient` (`ShippingClient/core/api_client.py`) con métodos `get_sill_dies`, `create_sill_die`, `update_sill_die`, `delete_sill_die`.
- Interfaz de usuario: añadido sub-tab "Die # Database" al módulo Sills con tabla, botones `Add/Edit/Delete/Refresh` y diálogos `SillDieDialog` para crear/editar dies, además de integración en `SillDialog` para autocompletar `die_number` y auto-rellenar `type`, `speed`, `width` y `notes` (si estaban vacíos) a partir de la tabla de dies en caché.

### Testing
- Se compiló todo el código con `python -m compileall ShippingServer ShippingClient` y la compilación fue exitosa.
- Se intentó ejecutar la suite con `pytest -q` en `ShippingServer`, pero la ejecución falló en este entorno por falta de la dependencia `fastapi` (error de importación), por lo que los tests no pudieron completarse aquí.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea4d08b3c08331862a16e16fc186eb)