### PR TITLE
Lock auto-filled Sills fields after die selection

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -252,14 +252,17 @@ class SillDialog(QDialog):
         completer.activated.connect(self._apply_die_data)
         die_widget.setCompleter(completer)
         die_widget.editingFinished.connect(lambda: self._apply_die_data(die_widget.text()))
+        self._apply_die_data(die_widget.text())
 
     def _apply_die_data(self, die_number: str) -> None:
         lookup_key = (die_number or "").strip().lower()
         if not lookup_key:
+            self._set_autofilled_fields_editable(True)
             return
 
         die_data = self._die_lookup.get(lookup_key)
         if not die_data:
+            self._set_autofilled_fields_editable(True)
             return
 
         text_fields = ("type", "width")
@@ -281,8 +284,17 @@ class SillDialog(QDialog):
                 speed_widget.setCurrentIndex(idx)
 
         notes_widget = self.inputs.get("notes")
-        if isinstance(notes_widget, QLineEdit) and not notes_widget.text().strip():
+        if isinstance(notes_widget, QLineEdit):
             notes_widget.setText(str(die_data.get("notes", "") or ""))
+        self._set_autofilled_fields_editable(False)
+
+    def _set_autofilled_fields_editable(self, editable: bool) -> None:
+        for field_name in ("type", "speed", "width", "notes"):
+            widget = self.inputs.get(field_name)
+            if isinstance(widget, QLineEdit):
+                widget.setReadOnly(not editable)
+            elif isinstance(widget, QComboBox):
+                widget.setEnabled(editable)
 
 
 class SillDieDialog(QDialog):


### PR DESCRIPTION
### Motivation

- Prevent users from modifying fields in the Sills form that are sourced from the Die database once a valid `Die #` is selected, since that data should be authoritative and not editable in the form.

### Description

- Initialize the die autofill on dialog creation by calling `_apply_die_data` from `_configure_die_autofill` so existing records open with correct editability state. 
- Update `_apply_die_data` to populate `Type`, `Speed`, `Width`, and `Notes` from the matched die and to set those fields to non-editable when a valid die is found. 
- Add `_set_autofilled_fields_editable` helper to toggle `QLineEdit` read-only and `QComboBox` enabled states for the auto-filled fields. 
- Ensure that clearing the `Die #` or entering a non-matching die re-enables editing for those fields.

### Testing

- Ran `python -m compileall ShippingClient/ui/main_window.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea57d4eb0c8331b6aa4be2d04bee62)