### PR TITLE
Reorganize Sill add/edit form into two visual sections and change Dimension label to Length

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -151,12 +151,12 @@ class TabPage(QWidget):
 class SillDialog(QDialog):
     FIELDS = [
         ("material", "Material"),
-        ("dimension", "Dimension"),
-        ("location", "Location"),
         ("die_number", "Die #"),
         ("type", "Type"),
         ("speed", "Speed"),
         ("width", "Width"),
+        ("location", "Location"),
+        ("dimension", "Length"),
         ("sales_order", "Sales Order"),
         ("work_order", "Work Order"),
         ("assembly_number", "Assembly Number"),
@@ -189,7 +189,9 @@ class SillDialog(QDialog):
         form = QFormLayout()
         form.setSpacing(10)
 
-        for key, label in self.FIELDS:
+        first_section_fields = {"material", "die_number", "type", "speed", "width", "location", "dimension"}
+
+        for index, (key, label) in enumerate(self.FIELDS):
             if key == "material":
                 input_widget = QComboBox()
                 input_widget.addItems(["NS", "SS", "SS316", "BR", "AL"])
@@ -217,6 +219,13 @@ class SillDialog(QDialog):
                 input_widget.setText(value)
             form.addRow(QLabel(label), input_widget)
             self.inputs[key] = input_widget
+            if key in first_section_fields and index + 1 < len(self.FIELDS):
+                next_key = self.FIELDS[index + 1][0]
+                if next_key not in first_section_fields:
+                    separator = QFrame()
+                    separator.setFrameShape(QFrame.Shape.HLine)
+                    separator.setFrameShadow(QFrame.Shadow.Sunken)
+                    form.addRow(separator)
 
         self._configure_die_autofill()
         layout.addLayout(form)


### PR DESCRIPTION
### Motivation
- Present the Sill add/edit form fields in the requested visual order grouped into a top "main" block and a bottom details block. 
- Make the `dimension` field appear as "Length" in the UI while keeping the underlying model key unchanged. 
- Add a visual separator between the two blocks so users perceive the intended grouping.

### Description
- Reordered the `SillDialog.FIELDS` list to place `material`, `die_number`, `type`, `speed`, `width`, `location`, `dimension` first and the remaining fields after them, and changed the visible label for `dimension` to `Length` (key remains `dimension`).
- Replaced the simple `for` loop with an indexed loop and added a `first_section_fields` set to detect the boundary between the two sections. 
- Inserted a horizontal `QFrame` separator (`QFrame.Shape.HLine`) when transitioning from the first (main) group to the next group. 
- Kept existing die autofill logic and payload keys unchanged, so model/payload behavior is preserved.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` and it succeeded with no syntax errors. 
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea65025704833190a5b43060943dc3)