### PR TITLE
Agregar sección configurable de Mie Trak en Settings → Connections

### DIFF
--- a/ShippingClient/core/mie_trak_client.py
+++ b/ShippingClient/core/mie_trak_client.py
@@ -6,8 +6,46 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MIE_TRAK_SERVER = "GUNDMAIN"
+DEFAULT_MIE_TRAK_DATABASE = "GunderlinLive"
+DEFAULT_MIE_TRAK_USER = "mie"
+DEFAULT_MIE_TRAK_PASSWORD = "mie"
 
-def get_mie_trak_address(job_number: str) -> str:
+
+def get_mie_trak_databases(server: str = DEFAULT_MIE_TRAK_SERVER) -> list[str]:
+    """Return online database names available in the target SQL Server."""
+    conn = None
+    try:
+        conn = pymssql.connect(
+            server=server,
+            user=DEFAULT_MIE_TRAK_USER,
+            password=DEFAULT_MIE_TRAK_PASSWORD,
+            database="master",
+        )
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT name
+            FROM sys.databases
+            WHERE state_desc = 'ONLINE'
+            ORDER BY name
+            """
+        )
+        return [str(row[0]) for row in cursor.fetchall() if row and row[0]]
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def get_mie_trak_address(
+    job_number: str,
+    *,
+    server: str = DEFAULT_MIE_TRAK_SERVER,
+    database: str = DEFAULT_MIE_TRAK_DATABASE,
+) -> str:
     """Return the shipping address for a given job number.
 
     This function connects directly to the Mie Trak database, queries the
@@ -32,10 +70,10 @@ def get_mie_trak_address(job_number: str) -> str:
     conn = None
     try:
         conn = pymssql.connect(
-            server="GUNDMAIN",
-            user="mie",
-            password="mie",
-            database="GunderlinLive",
+            server=server,
+            user=DEFAULT_MIE_TRAK_USER,
+            password=DEFAULT_MIE_TRAK_PASSWORD,
+            database=database,
         )
         cursor = conn.cursor(as_dict=True)
 

--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -29,6 +29,28 @@ class SettingsManager:
             cleaned = cleaned.rstrip("/")
         self._settings.setValue("ws_url", cleaned)
 
+    def get_mie_trak_server(self) -> str:
+        """Return configured Mie Trak SQL Server name."""
+        value = self._settings.value("mie_trak_server", "GUNDMAIN")
+        cleaned = str(value or "").strip()
+        return cleaned or "GUNDMAIN"
+
+    def set_mie_trak_server(self, server: str) -> None:
+        """Persist Mie Trak SQL Server name."""
+        cleaned = str(server or "").strip()
+        self._settings.setValue("mie_trak_server", cleaned or "GUNDMAIN")
+
+    def get_mie_trak_database(self) -> str:
+        """Return configured Mie Trak database name."""
+        value = self._settings.value("mie_trak_database", "GunderlinLive")
+        cleaned = str(value or "").strip()
+        return cleaned or "GunderlinLive"
+
+    def set_mie_trak_database(self, database: str) -> None:
+        """Persist selected Mie Trak database name."""
+        cleaned = str(database or "").strip()
+        self._settings.setValue("mie_trak_database", cleaned or "GunderlinLive")
+
     def save_cell_colors(self, table_name: str, colors: dict[tuple[int, int], str]):
         """DEPRECATED: persist colors by (row, column) for legacy support."""
         serialized = {f"{r},{c}": color for (r, c), color in colors.items()}

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -3557,7 +3557,11 @@ class ModernShippingMainWindow(QMainWindow):
     def show_mie_trak_address(self, job_number: str):
         """Fetch and display Mie Trak address for a job directly from DB"""
         try:
-            address = get_mie_trak_address(job_number)
+            address = get_mie_trak_address(
+                job_number,
+                server=self.settings_mgr.get_mie_trak_server(),
+                database=self.settings_mgr.get_mie_trak_database(),
+            )
             QMessageBox.information(
                 self, "Mie Trak Address", address or "No address found"
             )

--- a/ShippingClient/ui/settings_dialog.py
+++ b/ShippingClient/ui/settings_dialog.py
@@ -16,11 +16,12 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtGui import QFont
 from PyQt6.QtCore import Qt
 
-from .widgets import ModernButton, ModernLineEdit
+from .widgets import ModernButton, ModernComboBox, ModernLineEdit
 from .user_dialog import UserManagementWidget
 from core.settings_manager import SettingsManager
 from core.config import MODERN_FONT
 from core.api_client import RobustApiClient
+from core.mie_trak_client import get_mie_trak_databases
 from .utils import apply_scaled_font
 from .style_tokens import (
     COLOR_BG_SUBTLE,
@@ -191,6 +192,15 @@ class SettingsDialog(QDialog):
         self.test_fedex_btn.clicked.connect(self.test_fedex_connection)
         self.test_fedex_btn.setEnabled(self.is_admin)
 
+        self.mie_trak_server_edit = ModernLineEdit()
+        self.mie_trak_server_edit.setText("GUNDMAIN")
+        self.mie_trak_server_edit.setReadOnly(True)
+        self.mie_trak_database_combo = ModernComboBox()
+        self.mie_trak_database_combo.setEditable(True)
+        self.mie_trak_refresh_btn = ModernButton("Load Databases", "secondary")
+        self.mie_trak_refresh_btn.setMinimumWidth(140)
+        self.mie_trak_refresh_btn.clicked.connect(self.load_mie_trak_databases)
+
         server_section, server_content = self._create_connection_section("Server")
         self._add_form_row(server_content, "Server URL", self.server_edit)
 
@@ -217,6 +227,17 @@ class SettingsDialog(QDialog):
 
         layout.addWidget(server_section)
         layout.addWidget(ws_section)
+        mie_trak_section, mie_trak_content = self._create_connection_section("Mie Trak")
+        self._add_form_row(mie_trak_content, "Server Name", self.mie_trak_server_edit)
+        self._add_form_row(mie_trak_content, "Database", self.mie_trak_database_combo)
+        mie_trak_actions_row = QHBoxLayout()
+        mie_trak_actions_row.setContentsMargins(0, 0, 0, 0)
+        mie_trak_actions_row.setSpacing(SPACE_8)
+        mie_trak_actions_row.addStretch()
+        mie_trak_actions_row.addWidget(self.mie_trak_refresh_btn)
+        mie_trak_content.addLayout(mie_trak_actions_row)
+
+        layout.addWidget(mie_trak_section)
         layout.addWidget(fedex_section)
         layout.addStretch()
 
@@ -386,6 +407,11 @@ class SettingsDialog(QDialog):
         self.server_edit.setText(self.settings_mgr.get_server_url())
         self.ws_edit.setText(self.settings_mgr.get_ws_url())
         self.font_spin.setValue(self.settings_mgr.get_font_size())
+        self.mie_trak_server_edit.setText(self.settings_mgr.get_mie_trak_server())
+        self.mie_trak_database_combo.clear()
+        saved_database = self.settings_mgr.get_mie_trak_database()
+        self.mie_trak_database_combo.addItem(saved_database)
+        self.mie_trak_database_combo.setCurrentText(saved_database)
         response = self.api_client.get_connection_settings()
         if response.is_success():
             fedex = (response.get_data() or {}).get("fedex", {})
@@ -396,6 +422,27 @@ class SettingsDialog(QDialog):
                 self.fedex_secret_key_edit.setPlaceholderText("********")
         else:
             self.fedex_enabled.setChecked(False)
+
+    def load_mie_trak_databases(self):
+        server = self.mie_trak_server_edit.text().strip() or "GUNDMAIN"
+        current_database = self.mie_trak_database_combo.currentText().strip()
+        try:
+            databases = get_mie_trak_databases(server=server)
+        except Exception as exc:
+            QMessageBox.warning(
+                self,
+                "Mie Trak",
+                f"Could not load databases from {server}: {exc}",
+            )
+            return
+
+        self.mie_trak_database_combo.blockSignals(True)
+        self.mie_trak_database_combo.clear()
+        self.mie_trak_database_combo.addItems(databases)
+        if current_database:
+            self.mie_trak_database_combo.setCurrentText(current_database)
+        self.mie_trak_database_combo.blockSignals(False)
+        QMessageBox.information(self, "Mie Trak", f"{len(databases)} databases loaded.")
 
     def test_fedex_connection(self):
         if not self.is_admin:
@@ -414,10 +461,17 @@ class SettingsDialog(QDialog):
             QMessageBox.warning(self, "Error", "Both URLs are required")
             return
 
+        selected_mie_trak_db = self.mie_trak_database_combo.currentText().strip()
+        if not selected_mie_trak_db:
+            QMessageBox.warning(self, "Error", "Mie Trak database is required")
+            return
+
         self.settings_mgr.set_server_url(server)
         self.settings_mgr.set_ws_url(ws)
         new_size = self.font_spin.value()
         self.settings_mgr.set_font_size(new_size)
+        self.settings_mgr.set_mie_trak_server(self.mie_trak_server_edit.text().strip() or "GUNDMAIN")
+        self.settings_mgr.set_mie_trak_database(selected_mie_trak_db)
 
         enabled = self.fedex_enabled.isChecked()
         fedex_api_key = self.fedex_api_key_edit.text().strip()


### PR DESCRIPTION
### Motivation
- Permitir que la aplicación se conecte a la base de datos Mie Trak en la misma red y que el servidor/BD seleccionado se guarde en la configuración de la app. 

### Description
- Se añadió un bloque `Mie Trak` en `Settings → Connections` con campo `Server Name` (read-only, por defecto `GUNDMAIN`), un combo editable para `Database` y un botón `Load Databases` que consulta las bases disponibles.  
- `SettingsManager` incorpora `get_mie_trak_server`, `set_mie_trak_server`, `get_mie_trak_database` y `set_mie_trak_database` para persistir las opciones mediante `QSettings`.  
- `core/mie_trak_client.py` añade `get_mie_trak_databases(server=...)` que consulta `sys.databases` usando `pymssql` y cambia `get_mie_trak_address(...)` para aceptar `server` y `database` parametrizables con valores por defecto.  
- `main_window` ahora usa la configuración persistida (`SettingsManager`) al invocar `get_mie_trak_address(...)` para mostrar la dirección en pantalla.  

### Testing
- Se ejecutó la verificación de compilación por módulos con `python -m compileall ShippingClient/core/settings_manager.py ShippingClient/core/mie_trak_client.py ShippingClient/ui/settings_dialog.py ShippingClient/ui/main_window.py` y todas las compilaciones terminaron correctamente.  
- No se agregaron pruebas automatizadas; cambios validados por compilación estática de los módulos modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea6c5dec4c8331a697bcbd2db48ab8)