### PR TITLE
Widen header search bar and remove text borders in connection badge

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1124,7 +1124,7 @@ class ModernShippingMainWindow(QMainWindow):
         search_container = QFrame()
         search_container.setObjectName("commandSearchContainer")
         search_container.setMinimumHeight(CONTROL_HEIGHT)
-        search_container.setMaximumWidth(640)
+        search_container.setMaximumWidth(760)
         search_container.setSizePolicy(
             QSizePolicy.Policy.Expanding,
             QSizePolicy.Policy.Fixed,
@@ -1348,11 +1348,15 @@ class ModernShippingMainWindow(QMainWindow):
 
         self.connection_state_label = QLabel("Connected")
         apply_scaled_font(self.connection_state_label, offset=-2, weight=QFont.Weight.Medium)
-        self.connection_state_label.setStyleSheet(f"color: {COLOR_SUCCESS_SOFT_TEXT};")
+        self.connection_state_label.setStyleSheet(
+            f"color: {COLOR_SUCCESS_SOFT_TEXT}; border: none; background: transparent;"
+        )
 
         self.connection_host_label = QLabel(self.server_host)
         apply_scaled_font(self.connection_host_label, offset=-3, weight=QFont.Weight.Normal)
-        self.connection_host_label.setStyleSheet(f"color: {COLOR_TEXT_SECONDARY};")
+        self.connection_host_label.setStyleSheet(
+            f"color: {COLOR_TEXT_SECONDARY}; border: none; background: transparent;"
+        )
 
         self.connection_badge = QFrame()
         self.connection_badge.setStyleSheet(
@@ -3799,10 +3803,14 @@ class ModernShippingMainWindow(QMainWindow):
             self.connection_indicator.setToolTip(f"Connected to {self.server_host}")
             if hasattr(self, "connection_state_label"):
                 self.connection_state_label.setText("Connected")
-                self.connection_state_label.setStyleSheet(f"color: {COLOR_SUCCESS_SOFT_TEXT};")
+                self.connection_state_label.setStyleSheet(
+                    f"color: {COLOR_SUCCESS_SOFT_TEXT}; border: none; background: transparent;"
+                )
             if hasattr(self, "connection_host_label"):
                 self.connection_host_label.setText(self.server_host)
-                self.connection_host_label.setStyleSheet(f"color: {COLOR_TEXT_SECONDARY};")
+                self.connection_host_label.setStyleSheet(
+                    f"color: {COLOR_TEXT_SECONDARY}; border: none; background: transparent;"
+                )
             if hasattr(self, "connection_badge"):
                 self.connection_badge.setStyleSheet(
                     f"""
@@ -3822,10 +3830,14 @@ class ModernShippingMainWindow(QMainWindow):
             self.connection_indicator.setToolTip(f"Disconnected from {self.server_host}")
             if hasattr(self, "connection_state_label"):
                 self.connection_state_label.setText("Offline")
-                self.connection_state_label.setStyleSheet("color: #B91C1C;")
+                self.connection_state_label.setStyleSheet(
+                    "color: #B91C1C; border: none; background: transparent;"
+                )
             if hasattr(self, "connection_host_label"):
                 self.connection_host_label.setText(self.server_host)
-                self.connection_host_label.setStyleSheet("color: #9CA3AF;")
+                self.connection_host_label.setStyleSheet(
+                    "color: #9CA3AF; border: none; background: transparent;"
+                )
             if hasattr(self, "connection_badge"):
                 self.connection_badge.setStyleSheet(
                     """


### PR DESCRIPTION
### Motivation
- Make the header search input appear longer for better usability by increasing its allowed width. 
- Remove visible borders/artefacts around the connection badge text so the `Connected` label and host/IP render cleanly.

### Description
- Increased the header search container maximum width by changing `search_container.setMaximumWidth(640)` to `search_container.setMaximumWidth(760)` in `ShippingClient/ui/main_window.py`.
- Cleared visual artifacts on the connection badge by adding `border: none; background: transparent;` to the `connection_state_label` and `connection_host_label` styles during initial setup.
- Applied the same `border: none; background: transparent;` style updates in `update_connection_status` for both connected and disconnected branches so label updates remain artifact-free at runtime.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb53053a0c8331a465343b61504c6c)