### PR TITLE
Fix crash when opening Shipment History tab

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -4114,12 +4114,18 @@ class ModernShippingMainWindow(QMainWindow):
     
     def populate_active_table(self):
         """Poblar tabla activa"""
-        self.populate_table_fast(self.active_table, self._active_shipments, is_active=True)
+        table = self.tab_tables.get("active")
+        if table is None:
+            raise RuntimeError("Active shipments table is not initialized")
+        self.populate_table_fast(table, self._active_shipments, is_active=True)
     
     def populate_history_table(self):
         """Poblar tabla de historial"""
         print(f"Populando historial: {len(self._history_shipments)} shipments totales")
-        self.populate_table_fast(self.history_table, self._history_shipments, is_active=False)
+        table = self.tab_tables.get("history")
+        if table is None:
+            raise RuntimeError("Shipment history table is not initialized")
+        self.populate_table_fast(table, self._history_shipments, is_active=False)
 
     def populate_module_table(self, tab_id: str):
         if tab_id == "active":


### PR DESCRIPTION
### Motivation
- The app could crash with an opaque exception when switching to the Shipment History tab because code used direct attributes like `self.history_table` / `self.active_table` that may not be initialized in all tab-creation flows. The change aims to make table access robust to the central tab-registration approach.

### Description
- Replaced direct attribute usage in `populate_history_table` and `populate_active_table` with lookups through `self.tab_tables.get("history")` and `self.tab_tables.get("active")` respectively.
- Added explicit runtime guards that raise a clear `RuntimeError` when the target table is not initialized instead of allowing an `AttributeError` or other opaque crash.
- Kept change minimal and scoped to table retrieval in the population methods so tab behavior and table population logic remain unchanged.

### Testing
- Compiled the modified module with `python -m compileall ShippingClient/ui/main_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb597078408331a4988f1f0a22592b)