### PR TITLE
Avoid UI freeze when loading large Shipment History

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -779,6 +779,7 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
 
 class ModernShippingMainWindow(QMainWindow):
     _ROW_EXTRA_HEIGHT = 6
+    _HEAVY_LAYOUT_ROW_THRESHOLD = 1000
     DEFAULT_TABLE_COLUMNS = [
         "Job Number",
         "Job Name",
@@ -3271,8 +3272,9 @@ class ModernShippingMainWindow(QMainWindow):
         top_row = table.rowAt(0)
         bottom_row = table.rowAt(table.viewport().height() - 1)
         if top_row < 0 or bottom_row < 0:
-            table.resizeRowsToContents()
-            for row in range(row_count):
+            rows_to_measure = min(row_count, 200)
+            for row in range(rows_to_measure):
+                table.resizeRowToContents(row)
                 table.setRowHeight(row, table.rowHeight(row) + self._ROW_EXTRA_HEIGHT)
             return
 
@@ -4178,8 +4180,9 @@ class ModernShippingMainWindow(QMainWindow):
             self.apply_row_filters(table, table_name)
 
             table.setUpdatesEnabled(True)
-            self._ensure_columns_fit_content(table)
-            self._refresh_visible_row_heights(table)
+            if row_count <= self._HEAVY_LAYOUT_ROW_THRESHOLD:
+                self._ensure_columns_fit_content(table)
+                self._refresh_visible_row_heights(table)
             self.refresh_pinned_columns(table, table_name)
             self.updating_table = False
             print(


### PR DESCRIPTION
### Motivation
- Loading thousands of shipments in the Shipment History triggered expensive layout passes and full-row measurements that blocked the UI thread and caused the app to become unresponsive or crash.

### Description
- Add a `_HEAVY_LAYOUT_ROW_THRESHOLD = 1000` constant to guard heavy layout work for large tables.
- Skip expensive auto-fit passes (`_ensure_columns_fit_content` and `_refresh_visible_row_heights`) in `populate_table_fast` when `row_count` exceeds the threshold to avoid long synchronous work on the UI thread.
- Change `_refresh_visible_row_heights` fallback (when viewport rows are not yet available) to measure at most 200 rows and avoid calling `resizeRowsToContents()` on the entire table.
- Preserve periodic `QApplication.processEvents()` during population to keep the UI responsive while filling rows.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` which completed successfully.
- Ran `pytest -q test_api_client.py test_mie_trak_client.py` which failed to collect due to a missing dependency in the test environment (`requests`) and is therefore not indicative of this change's behavior; no functional test failures from the modified file were encountered in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5c0526488331897f9ea54a07bda0)