### PR TITLE
Fix shipment history tab freezing during chunked population

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -4210,11 +4210,17 @@ class ModernShippingMainWindow(QMainWindow):
             print(f"Error poblando tabla: {e}")
             raise
 
-    def _cancel_table_population(self):
+    def _cancel_table_population(self, restore_table_state: bool = True):
         if self._table_population_timer is not None:
             self._table_population_timer.stop()
             self._table_population_timer.deleteLater()
             self._table_population_timer = None
+        if restore_table_state and self._table_population_state is not None:
+            table = self._table_population_state.get("table")
+            if table is not None:
+                table.setUpdatesEnabled(True)
+                table.blockSignals(False)
+            self.updating_table = False
         self._table_population_state = None
 
     def _populate_table_chunked(
@@ -4235,12 +4241,12 @@ class ModernShippingMainWindow(QMainWindow):
             "sort_col": sort_col,
             "sort_order": sort_order,
             "table_name": table_name,
-            "chunk_size": 200,
+            "chunk_size": 120,
         }
         timer = QTimer(self)
         timer.timeout.connect(self._process_population_chunk)
         self._table_population_timer = timer
-        timer.start(0)
+        timer.start(1)
 
     def _process_population_chunk(self):
         state = self._table_population_state
@@ -4255,10 +4261,15 @@ class ModernShippingMainWindow(QMainWindow):
         chunk_size = state["chunk_size"]
         is_active = state["is_active"]
 
-        end = min(index + chunk_size, row_count)
-        for row in range(index, end):
-            self.populate_table_row(table, row, shipments[row], is_active)
-        state["index"] = end
+        try:
+            end = min(index + chunk_size, row_count)
+            for row in range(index, end):
+                self.populate_table_row(table, row, shipments[row], is_active)
+            state["index"] = end
+        except Exception as exc:
+            print(f"Error during chunked table population: {exc}")
+            self._cancel_table_population(restore_table_state=True)
+            return
 
         if end < row_count:
             return


### PR DESCRIPTION
### Motivation
- Loading very large Shipment History lists could leave the UI unresponsive or a table with updates/signals disabled when switching tabs or when an exception occurred during chunked rendering.

### Description
- Modified `_cancel_table_population` to accept `restore_table_state: bool = True` and restore `table.setUpdatesEnabled(True)`, `table.blockSignals(False)` and `self.updating_table = False` when cancelling population.
- Reduced chunk size from `200` to `120` and changed `timer.start(0)` to `timer.start(1)` to yield more frequently to the UI thread while rendering rows.
- Added defensive `try/except` in `_process_population_chunk` to log exceptions and cancel the chunked population while restoring table state to avoid silent hangs.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5f10d3688331ace3d3054ae697ae)