### PR TITLE
Auto-clear persisted date filters that hide all shipments

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -901,6 +901,7 @@ class ModernShippingMainWindow(QMainWindow):
         self._tables_populated = {module.id: False for module in self.tab_modules}
         self._search_row_visibility = {module.id: [] for module in self.tab_modules}
         self.date_filters = {module.id: self.settings_mgr.load_date_filters(module.id) for module in self.tab_modules}
+        self._auto_reset_filter_tabs: set[str] = set()
         self._base_header_labels: dict[str, list[str]] = {}
         self.date_filter_headers = {}
         self._header_shadows: dict[str, QGraphicsDropShadowEffect] = {}
@@ -3892,6 +3893,29 @@ class ModernShippingMainWindow(QMainWindow):
         """Mostrar notificación visual flotante"""
         show_popup_notification(self, message, color=color)
     
+    def _recover_hidden_rows_from_saved_filters(self, tab_id: str):
+        """Clear persisted date filters once when they hide all loaded rows."""
+        if tab_id in self._auto_reset_filter_tabs:
+            return
+
+        table = self.tab_tables.get(tab_id)
+        if table is None:
+            return
+        if table.rowCount() == 0:
+            return
+        if self.count_visible_rows(table) > 0:
+            return
+        if self.search_edit.text().strip():
+            return
+
+        saved_filters = self.date_filters.get(tab_id, {})
+        if not saved_filters:
+            return
+
+        self._auto_reset_filter_tabs.add(tab_id)
+        self.clear_all_filters(tab_id)
+        self.show_toast("Saved filters were hiding all rows. Filters were cleared.", color="#0EA5E9")
+
     def on_tab_changed(self, index):
         """Manejar cambio de tab optimizado"""
         print(f"Cambio de tab: {index}")
@@ -3901,6 +3925,10 @@ class ModernShippingMainWindow(QMainWindow):
         elif not self._tables_populated.get(tab_id, False):
             self.populate_module_table(tab_id)
             self._tables_populated[tab_id] = True
+
+        if tab_id in {"active", "history"}:
+            self._recover_hidden_rows_from_saved_filters(tab_id)
+
         self._apply_module_toolbar_state(tab_id)
 
         self.update_status()
@@ -4054,6 +4082,7 @@ class ModernShippingMainWindow(QMainWindow):
         else:
             self.populate_module_table(current_tab_id)
             self._tables_populated[current_tab_id] = True
+            self._recover_hidden_rows_from_saved_filters(current_tab_id)
 
         self.update_status()
         self.update_filter_button_state()


### PR DESCRIPTION
### Motivation
- Users could open the Shipping tabs (Active/History) and see an apparently empty/frozen table when previously persisted date filters excluded every loaded row. This caused confusion while the underlying data was present.

### Description
- Added a per-window guard `_auto_reset_filter_tabs` to avoid repeatedly auto-clearing filters for the same tab.
- Implemented `_recover_hidden_rows_from_saved_filters(tab_id)` which detects when a populated table has 0 visible rows (and no search text) and clears the persisted date filters once while showing a toast explaining the action.
- Invoked the recovery guard when the app finishes loading shipments (`on_shipments_loaded`) and when the user switches sub-tabs (`on_tab_changed`) for the `active` and `history` tabs.
- Change applied to `ShippingClient/ui/main_window.py` and preserves normal filter behavior while recovering from the edge case.

### Testing
- Compiled the modified file with `python -m py_compile ShippingClient/ui/main_window.py`, and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb601f23f88331976d03f21f57218c)