### PR TITLE
Limit history rendering and harden shipment loader to prevent UI freezes

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -523,7 +523,9 @@ class ShipmentLoader(QThread):
         try:
             api_response = self.api_client.get_shipments()
             if api_response.is_success():
-                shipments = api_response.get_data()
+                shipments = api_response.get_data() or []
+                if not isinstance(shipments, list):
+                    shipments = []
                 self.data_loaded.emit(shipments)
             else:
                 self.error_occurred.emit(api_response.get_error())
@@ -780,6 +782,7 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
 class ModernShippingMainWindow(QMainWindow):
     _ROW_EXTRA_HEIGHT = 6
     _HEAVY_LAYOUT_ROW_THRESHOLD = 1000
+    _MAX_HISTORY_ROWS = 5000
     DEFAULT_TABLE_COLUMNS = [
         "Job Number",
         "Job Name",
@@ -896,6 +899,7 @@ class ModernShippingMainWindow(QMainWindow):
 
         # Cache para optimización
         self._active_shipments = []
+        self._history_total_count = 0
         self._history_shipments = []
         self._last_filter_text = ""
         self._tables_populated = {module.id: False for module in self.tab_modules}
@@ -4004,6 +4008,32 @@ class ModernShippingMainWindow(QMainWindow):
         shipped_date = str(shipped_date).strip()
         return bool(shipped_date and shipped_date.lower() not in ["", "n/a", "pending", "tbd"])
 
+    def _parse_history_sort_date(self, shipment: dict) -> datetime:
+        for field in ("shipped", "updated_at", "created"):
+            parsed = DateSortableItem._parse(shipment.get(field))
+            if parsed:
+                return parsed
+        return datetime.min
+
+    def _build_history_view(self, history_shipments: list[dict]) -> list[dict]:
+        self._history_total_count = len(history_shipments)
+        if self._history_total_count <= self._MAX_HISTORY_ROWS:
+            return history_shipments
+
+        sorted_history = sorted(
+            history_shipments,
+            key=self._parse_history_sort_date,
+            reverse=True,
+        )
+        trimmed = sorted_history[: self._MAX_HISTORY_ROWS]
+        hidden_count = self._history_total_count - len(trimmed)
+        self.show_toast(
+            f"Showing latest {len(trimmed)} of {self._history_total_count} history records "
+            f"to keep the app responsive ({hidden_count} older records hidden).",
+            color="#F59E0B",
+        )
+        return trimmed
+
     def _show_loading_indicator(self):
         """Mostrar indicador de progreso y desactivar controles"""
         self._hide_loading_indicator()
@@ -4069,7 +4099,8 @@ class ModernShippingMainWindow(QMainWindow):
         
         # Separar datos para cache
         self._active_shipments = [s for s in shipments if not self.is_shipped(s)]
-        self._history_shipments = [s for s in shipments if self.is_shipped(s)]
+        history_shipments = [s for s in shipments if self.is_shipped(s)]
+        self._history_shipments = self._build_history_view(history_shipments)
         
         # Marcar tablas como no pobladas
         self._tables_populated = {module.id: False for module in self.tab_modules}
@@ -4579,7 +4610,7 @@ class ModernShippingMainWindow(QMainWindow):
         if current_tab_id == "active":
             total_count = len(self._active_shipments)
         elif current_tab_id == "history":
-            total_count = len(self._history_shipments)
+            total_count = self._history_total_count or len(self._history_shipments)
 
         self.record_count_label.setText(f"Showing {visible_count} of {total_count}")
 


### PR DESCRIPTION
### Motivation

- La vista "Shipment History" se estaba congelando/crasheando cuando el backend devolvía muchos registros históricos o datos inesperados, lo que dejaba la interfaz bloqueada al renderizar toda la lista en memoria. 
- El loader de shipments podía recibir valores nulos o no-lista desde la API y provocar errores en el cliente al procesar la respuesta.

### Description

- Se robusteció `ShipmentLoader.run` para que siempre emita una lista válida (`shipments = api_response.get_data() or []` y validación de tipo) evitando fallos por payloads nulos/no-lista. 
- Se añadió la constante ` _MAX_HISTORY_ROWS = 5000` y la propiedad `self._history_total_count` para limitar cuántas filas históricas se renderizan en el cliente y retener el conteo total. 
- Se implementaron los métodos privados ` _parse_history_sort_date` y ` _build_history_view` para ordenar el historial por fecha relevante (`shipped`, `updated_at`, `created`) y devolver solo los registros más recientes cuando se excede el límite, mostrando un `toast` avisando del recorte. 
- Se actualizó `on_shipments_loaded` para usar la vista optimizada (`_build_history_view`) y `update_status` para mostrar el conteo total real en la barra de estado (`_history_total_count`).

### Testing

- Se compiló el archivo modificado con `python -m compileall ShippingClient/ui/main_window.py` y la compilación fue exitosa. 
- Se ejecutó `pytest -q`, el cual falló en la fase de recolección por dependencias del entorno ausentes (`ModuleNotFoundError: No module named 'fastapi'` y `No module named 'requests'`), por lo que no se pudieron ejecutar los tests automatizados en este entorno de CI local.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb637dd65483319485ade30a720088)