### PR TITLE
Make `current_version` optional for shipment updates (legacy client compatibility)

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -721,7 +721,10 @@ async def create_shipment(
 async def update_shipment(
     shipment_id: int,
     shipment_update: ShipmentUpdate,
-    current_version: int = Query(..., description="Current version for optimistic locking"),
+    current_version: int | None = Query(
+        None,
+        description="Current version for optimistic locking (optional for legacy clients)",
+    ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -732,11 +735,14 @@ async def update_shipment(
     try:
         logger.info(f"Updating shipment {shipment_id}, version {current_version}")
 
-        # Buscar con version lock
-        shipment = db.query(Shipment).filter(
-            Shipment.id == shipment_id,
-            Shipment.version == current_version
-        ).first()
+        # Buscar shipment; usar lock optimista solo cuando el cliente envía versión
+        if current_version is None:
+            shipment = db.query(Shipment).filter(Shipment.id == shipment_id).first()
+        else:
+            shipment = db.query(Shipment).filter(
+                Shipment.id == shipment_id,
+                Shipment.version == current_version
+            ).first()
 
         if not shipment:
             # Verificar si existe pero con versión diferente


### PR DESCRIPTION
### Motivation
- Older clients sometimes call `PUT /shipments/{shipment_id}` without sending `current_version`, causing updates to fail and preventing fields like `shipped` from being saved and shown in shipment history. 
- The endpoint should remain safe for optimistic locking but accept legacy calls that don't provide a version.

### Description
- Changed the `update_shipment` signature to accept `current_version: int | None = Query(None)` in `ShippingServer/main.py` so the parameter is optional for legacy clients. 
- When `current_version` is provided the handler preserves optimistic locking and queries by both `id` and `version`, and when it is omitted the handler falls back to querying by `id` only. 
- Kept the existing 409 conflict behavior when a version mismatch is detected and preserved input validation, change logging, version bumping, and WebSocket notifications.

### Testing
- Ran `python -m compileall ShippingServer/main.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb713586b48331aba0fcec80c2f7c0)