### PR TITLE
Improve large-table rendering performance and add diagnostics; log shipments query timing

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1,6 +1,7 @@
 ﻿# ui/main_window.py - Ventana principal con diseño profesional
 import csv
 import json
+import time
 from dataclasses import dataclass, field
 from datetime import datetime, date, timedelta
 from typing import Optional, Dict, Any
@@ -782,6 +783,7 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
 class ModernShippingMainWindow(QMainWindow):
     _ROW_EXTRA_HEIGHT = 6
     _HEAVY_LAYOUT_ROW_THRESHOLD = 1000
+    _HISTORY_CHUNK_THRESHOLD = 250
     _MAX_HISTORY_ROWS = 5000
     DEFAULT_TABLE_COLUMNS = [
         "Job Number",
@@ -931,6 +933,7 @@ class ModernShippingMainWindow(QMainWindow):
         self._pending_shipment_reload = False
         self._table_population_timer: Optional[QTimer] = None
         self._table_population_state: Optional[dict[str, Any]] = None
+        self._history_tab_entered_at: Optional[float] = None
         self.shipping_logs = []
         self.sills = []
         self.sill_dies = []
@@ -2611,6 +2614,8 @@ class ModernShippingMainWindow(QMainWindow):
         self.refresh_pinned_columns(table, name)
 
     def refresh_status_chip_for_row(self, table, row):
+        if self.updating_table:
+            return
         if table is None or row < 0 or row >= table.rowCount():
             return
         index = table.model().index(row, 0)
@@ -3937,11 +3942,19 @@ class ModernShippingMainWindow(QMainWindow):
 
     def on_tab_changed(self, index):
         """Manejar cambio de tab optimizado"""
-        print(f"Cambio de tab: {index}")
+        tab_switched_at = time.perf_counter()
+        print(f"[TAB] Cambio de tab index={index}")
         tab_id = self.tab_index_to_id.get(index, self.get_current_tab_id())
+        print(f"[TAB] tab_id={tab_id}")
         if tab_id == "logs":
             self.load_shipping_logs()
         elif not self._tables_populated.get(tab_id, False):
+            if tab_id == "history":
+                self._history_tab_entered_at = tab_switched_at
+                print(
+                    f"[HISTORY_DIAG] entering history tab with loaded_rows={len(self._history_shipments)} "
+                    f"total_history={self._history_total_count}"
+                )
             self.populate_module_table(tab_id)
             self._tables_populated[tab_id] = True
 
@@ -3953,6 +3966,8 @@ class ModernShippingMainWindow(QMainWindow):
         self.update_status()
         self.on_selection_changed()
         self.update_filter_button_state()
+        elapsed_ms = (time.perf_counter() - tab_switched_at) * 1000
+        print(f"[TAB] tab change processing done in {elapsed_ms:.1f}ms for tab_id={tab_id}")
 
     def on_main_tab_changed(self, index):
         _ = index
@@ -4231,7 +4246,10 @@ class ModernShippingMainWindow(QMainWindow):
     
     def populate_history_table(self):
         """Poblar tabla de historial"""
-        print(f"Populando historial: {len(self._history_shipments)} shipments totales")
+        print(
+            f"[HISTORY_DIAG] Populating history table rows={len(self._history_shipments)} "
+            f"(cached_total={self._history_total_count})"
+        )
         table = self.tab_tables.get("history")
         if table is None:
             raise RuntimeError("Shipment history table is not initialized")
@@ -4254,6 +4272,7 @@ class ModernShippingMainWindow(QMainWindow):
     def populate_table_fast(self, table, shipments, is_active=True):
         """Poblar tabla de forma optimizada"""
         try:
+            start = time.perf_counter()
             self._cancel_table_population()
             self.updating_table = True
             table.setUpdatesEnabled(False)
@@ -4268,8 +4287,16 @@ class ModernShippingMainWindow(QMainWindow):
 
             row_count = len(shipments)
             table.setRowCount(row_count)
+            table_name = "active" if is_active else "history"
+            heavy_layout_threshold = (
+                self._HEAVY_LAYOUT_ROW_THRESHOLD if is_active else self._HISTORY_CHUNK_THRESHOLD
+            )
+            print(
+                f"[TABLE_POP] start table={table_name} rows={row_count} "
+                f"chunk_threshold={heavy_layout_threshold}"
+            )
 
-            if row_count > self._HEAVY_LAYOUT_ROW_THRESHOLD:
+            if row_count > heavy_layout_threshold:
                 self._populate_table_chunked(
                     table=table,
                     shipments=shipments,
@@ -4277,6 +4304,9 @@ class ModernShippingMainWindow(QMainWindow):
                     sort_col=sort_col,
                     sort_order=sort_order,
                 )
+                # Keep paint updates enabled during chunked mode so the UI
+                # does not appear fully frozen while rows are being inserted.
+                table.setUpdatesEnabled(True)
                 return
 
             for row, shipment in enumerate(shipments):
@@ -4290,7 +4320,6 @@ class ModernShippingMainWindow(QMainWindow):
             if sort_col >= 0:
                 table.sortItems(sort_col, sort_order)
 
-            table_name = "active" if is_active else "history"
             self.apply_saved_cell_colors(table, table_name)
 
             # Inicializar estado de búsqueda y aplicar filtros combinados
@@ -4300,14 +4329,13 @@ class ModernShippingMainWindow(QMainWindow):
             self.apply_row_filters(table, table_name)
 
             table.setUpdatesEnabled(True)
-            if row_count <= self._HEAVY_LAYOUT_ROW_THRESHOLD:
+            if row_count <= heavy_layout_threshold:
                 self._ensure_columns_fit_content(table)
                 self._refresh_visible_row_heights(table)
             self.refresh_pinned_columns(table, table_name)
             self.updating_table = False
-            print(
-                f"Tabla {'activa' if is_active else 'historial'} poblada: {row_count} filas"
-            )
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            print(f"[TABLE_POP] done table={table_name} rows={row_count} in {elapsed_ms:.1f}ms")
             
         except Exception as e:
             table.setUpdatesEnabled(True)
@@ -4338,6 +4366,7 @@ class ModernShippingMainWindow(QMainWindow):
         sort_order: Qt.SortOrder,
     ):
         table_name = "active" if is_active else "history"
+        chunk_size = 80 if is_active else 25
         self._table_population_state = {
             "table": table,
             "shipments": shipments,
@@ -4347,12 +4376,17 @@ class ModernShippingMainWindow(QMainWindow):
             "sort_col": sort_col,
             "sort_order": sort_order,
             "table_name": table_name,
-            "chunk_size": 120,
+            "chunk_size": chunk_size,
+            "started_at": time.perf_counter(),
+            "next_progress_mark": 500,
         }
         timer = QTimer(self)
         timer.timeout.connect(self._process_population_chunk)
         self._table_population_timer = timer
         timer.start(1)
+        print(
+            f"[TABLE_POP] chunked mode table={table_name} rows={len(shipments)} chunk_size={chunk_size}"
+        )
 
     def _process_population_chunk(self):
         state = self._table_population_state
@@ -4371,7 +4405,14 @@ class ModernShippingMainWindow(QMainWindow):
             end = min(index + chunk_size, row_count)
             for row in range(index, end):
                 self.populate_table_row(table, row, shipments[row], is_active)
+                if row and row % 10 == 0:
+                    QApplication.processEvents(QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents)
             state["index"] = end
+            table.viewport().update()
+            next_progress_mark = state.get("next_progress_mark", row_count + 1)
+            if end >= next_progress_mark:
+                print(f"[TABLE_POP] progress table={state['table_name']} rows_loaded={end}/{row_count}")
+                state["next_progress_mark"] = next_progress_mark + 500
         except Exception as exc:
             print(f"Error during chunked table population: {exc}")
             self._cancel_table_population(restore_table_state=True)
@@ -4382,6 +4423,7 @@ class ModernShippingMainWindow(QMainWindow):
 
         sort_col = state["sort_col"]
         sort_order = state["sort_order"]
+        started_at = state.get("started_at")
         self._cancel_table_population()
         self._finalize_table_population(
             table=table,
@@ -4390,6 +4432,7 @@ class ModernShippingMainWindow(QMainWindow):
             sort_col=sort_col,
             sort_order=sort_order,
             run_expensive_layout=False,
+            started_at=started_at,
         )
 
     def _finalize_table_population(
@@ -4400,6 +4443,7 @@ class ModernShippingMainWindow(QMainWindow):
         sort_col: int,
         sort_order: Qt.SortOrder,
         run_expensive_layout: bool,
+        started_at: Optional[float] = None,
     ):
         table_name = "active" if is_active else "history"
         table.setSortingEnabled(True)
@@ -4419,7 +4463,14 @@ class ModernShippingMainWindow(QMainWindow):
             self._refresh_visible_row_heights(table)
         self.refresh_pinned_columns(table, table_name)
         self.updating_table = False
-        print(f"Tabla {'activa' if is_active else 'historial'} poblada: {row_count} filas")
+        if started_at is not None:
+            elapsed_ms = (time.perf_counter() - started_at) * 1000
+            print(f"[TABLE_POP] done table={table_name} rows={row_count} in {elapsed_ms:.1f}ms (chunked)")
+        else:
+            print(f"[TABLE_POP] done table={table_name} rows={row_count} (chunked)")
+        if table_name == "history" and self._history_tab_entered_at is not None:
+            tab_elapsed = (time.perf_counter() - self._history_tab_entered_at) * 1000
+            print(f"[HISTORY_DIAG] history tab fully rendered in {tab_elapsed:.1f}ms")
 
     def _prepare_cell_metadata(self, column: int, value) -> dict[str, object]:
         raw_text = "" if value is None else str(value)

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -7,6 +7,7 @@ from datetime import timedelta, datetime, date
 import json
 import asyncio
 import logging
+import time
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm.exc import StaleDataError
 
@@ -581,7 +582,21 @@ async def get_fedex_tracking(
 
 @app.get("/shipments", response_model=List[ShipmentResponse])
 async def get_shipments(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    started_at = time.perf_counter()
     shipments = db.query(Shipment).all()
+    elapsed_ms = (time.perf_counter() - started_at) * 1000
+    shipped_count = sum(1 for shipment in shipments if str(getattr(shipment, "shipped", "") or "").strip())
+    avg_notes_len = 0.0
+    if shipments:
+        avg_notes_len = sum(len(str(getattr(shipment, "shipping_notes", "") or "")) for shipment in shipments) / len(shipments)
+    logger.info(
+        "GET /shipments user=%s rows=%s shipped_rows=%s avg_shipping_notes_len=%.1f query_time_ms=%.1f",
+        getattr(current_user, "username", "unknown"),
+        len(shipments),
+        shipped_count,
+        avg_notes_len,
+        elapsed_ms,
+    )
     return shipments
 
 @app.get("/shipments/{shipment_id}", response_model=ShipmentResponse)


### PR DESCRIPTION
### Motivation
- Reduce UI jank and make large table (history/active) population more responsive by introducing chunked loading behavior and better event processing. 
- Add runtime diagnostics to help measure and debug tab switching and table population latency. 
- Add server-side timing and usage telemetry for the `/shipments` endpoint to aid production monitoring.

### Description
- Introduce `time` imports and a new `_HISTORY_CHUNK_THRESHOLD` plus `_history_tab_entered_at` to differentiate history vs active chunking behavior and record history tab enter time. 
- Make table population chunked: add `_populate_table_chunked`, per-module `chunk_size` (80 for active, 25 for history), `started_at` and `next_progress_mark` state, periodic `QApplication.processEvents(...)` calls, `table.viewport().update()` and progress `print` diagnostics. 
- Add timing and diagnostic `print` statements in `on_tab_changed`, `populate_history_table`, `populate_table_fast`, `_process_population_chunk`, and `_finalize_table_population` to log durations and progress. 
- Prevent status-chip refresh during table updates by guarding `refresh_status_chip_for_row` with `if self.updating_table: return`. 
- Ensure `table.setUpdatesEnabled(True)` is left enabled during chunked loading to keep the UI responsive and track elapsed times; apply saved cell colors and finalize sorting/filters after chunk completion. 
- On the server, add `time` import and record/query timing and simple metrics in `GET /shipments` with a `logger.info` that includes request user, number of rows, shipped rows, average shipping notes length, and query time.

### Testing
- Ran the project test suite with `pytest -q` and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb764ecfcc83318dc3e3f0a4fedba6)