### PR TITLE
Improve shipment table rendering performance

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -3262,7 +3262,9 @@ class ModernShippingMainWindow(QMainWindow):
 
         default_height = max(46, int(metrics.lineSpacing() * 1.72)) + self._ROW_EXTRA_HEIGHT
 
-        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        # ResizeToContents forces Qt to measure every row on inserts/updates and
+        # becomes prohibitively expensive on large tables (especially history).
+        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
         vertical_header.setMinimumSectionSize(default_height)
         vertical_header.setDefaultSectionSize(default_height)
 
@@ -4361,9 +4363,6 @@ class ModernShippingMainWindow(QMainWindow):
                     sort_col=sort_col,
                     sort_order=sort_order,
                 )
-                # Keep paint updates enabled during chunked mode so the UI
-                # does not appear fully frozen while rows are being inserted.
-                table.setUpdatesEnabled(True)
                 return
 
             for row, shipment in enumerate(shipments):
@@ -4480,7 +4479,7 @@ class ModernShippingMainWindow(QMainWindow):
         sort_col = state["sort_col"]
         sort_order = state["sort_order"]
         started_at = state.get("started_at")
-        self._cancel_table_population()
+        self._cancel_table_population(restore_table_state=False)
         self._finalize_table_population(
             table=table,
             row_count=row_count,


### PR DESCRIPTION
### Motivation
- Large history tables were extremely slow because `ResizeToContents` on the vertical header forces Qt to measure every row on inserts/updates, causing O(n²) behavior for many rows.
- Chunked population re-enabled painting/state too early which triggered repeated relayout/repaint work between chunks and made the UI appear sluggish.

### Description
- Change vertical header sizing in `_configure_table_row_metrics` from `QHeaderView.ResizeMode.ResizeToContents` to `QHeaderView.ResizeMode.Fixed` and set sensible default/minimum heights to avoid per-row measuring overhead.
- Remove the early `table.setUpdatesEnabled(True)` during chunked population so updates remain disabled while rows are still being inserted.
- Call `_cancel_table_population(restore_table_state=False)` at chunk completion to avoid restoring table state mid-flight and let `_finalize_table_population` handle re-enabling updates and running expensive layout once.
- Add a short comment explaining why `Fixed` is used to document the performance rationale.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb837d9d188331b079be2918d8f0e8)