### PR TITLE
Improve table performance and remove history pagination cap

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -784,8 +784,6 @@ class ModernShippingMainWindow(QMainWindow):
     _ROW_EXTRA_HEIGHT = 6
     _HEAVY_LAYOUT_ROW_THRESHOLD = 1000
     _HISTORY_CHUNK_THRESHOLD = 250
-    _MAX_HISTORY_ROWS = 5000
-    _HISTORY_PAGE_SIZE = 300
     DEFAULT_TABLE_COLUMNS = [
         "Job Number",
         "Job Name",
@@ -1605,7 +1603,7 @@ class ModernShippingMainWindow(QMainWindow):
             padding=(6, 10),
         )
         history_load_more_btn.clicked.connect(self.load_more_history_rows)
-        history_load_more_btn.setVisible(module.id == "history")
+        history_load_more_btn.setVisible(False)
         secondary_layout.addWidget(print_btn)
         secondary_layout.addWidget(columns_btn)
         secondary_layout.addWidget(export_btn)
@@ -3262,7 +3260,9 @@ class ModernShippingMainWindow(QMainWindow):
 
         default_height = max(46, int(metrics.lineSpacing() * 1.72)) + self._ROW_EXTRA_HEIGHT
 
-        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
+        # ResizeToContents forces Qt to measure every row on inserts/updates and
+        # becomes prohibitively expensive on large tables (especially history).
+        vertical_header.setSectionResizeMode(QHeaderView.ResizeMode.Fixed)
         vertical_header.setMinimumSectionSize(default_height)
         vertical_header.setDefaultSectionSize(default_height)
 
@@ -4058,30 +4058,12 @@ class ModernShippingMainWindow(QMainWindow):
         )
         self._all_history_shipments = sorted_history
         self._history_total_count = len(sorted_history)
-        capped_history = sorted_history[: self._MAX_HISTORY_ROWS]
-        initial_count = min(len(capped_history), self._HISTORY_PAGE_SIZE)
-
-        if self._history_total_count > self._MAX_HISTORY_ROWS:
-            hidden_count = self._history_total_count - len(capped_history)
-            self.show_toast(
-                f"Showing latest {len(capped_history)} of {self._history_total_count} history records "
-                f"to keep the app responsive ({hidden_count} older records hidden).",
-                color="#F59E0B",
-            )
-
-        if len(capped_history) > initial_count:
-            self.show_toast(
-                f"Shipment History loaded in pages of {self._HISTORY_PAGE_SIZE}. "
-                f"Currently showing {initial_count} of {len(capped_history)}.",
-                color="#0EA5E9",
-            )
-
-        return capped_history[:initial_count]
+        return sorted_history
 
     def _history_effective_total(self) -> int:
         if not self._all_history_shipments:
             return 0
-        return min(len(self._all_history_shipments), self._MAX_HISTORY_ROWS)
+        return len(self._all_history_shipments)
 
     def _history_loaded_count(self) -> int:
         return len(self._history_shipments)
@@ -4125,15 +4107,9 @@ class ModernShippingMainWindow(QMainWindow):
         if not isinstance(history_load_more_btn, QWidget):
             return
 
-        hidden_count = self._history_hidden_count()
-        should_show = hidden_count > 0
-        history_load_more_btn.setVisible(should_show)
-        history_load_more_btn.setEnabled(should_show)
-
-        if hasattr(history_load_more_btn, "setText"):
-            history_load_more_btn.setText(
-                f"Load More ({hidden_count})" if should_show else "Load More"
-            )
+        # History pagination was removed; always keep this legacy control hidden.
+        history_load_more_btn.setVisible(False)
+        history_load_more_btn.setEnabled(False)
 
     def load_more_history_rows(self):
         hidden_count = self._history_hidden_count()
@@ -4361,9 +4337,6 @@ class ModernShippingMainWindow(QMainWindow):
                     sort_col=sort_col,
                     sort_order=sort_order,
                 )
-                # Keep paint updates enabled during chunked mode so the UI
-                # does not appear fully frozen while rows are being inserted.
-                table.setUpdatesEnabled(True)
                 return
 
             for row, shipment in enumerate(shipments):
@@ -4480,7 +4453,7 @@ class ModernShippingMainWindow(QMainWindow):
         sort_col = state["sort_col"]
         sort_order = state["sort_order"]
         started_at = state.get("started_at")
-        self._cancel_table_population()
+        self._cancel_table_population(restore_table_state=False)
         self._finalize_table_population(
             table=table,
             row_count=row_count,


### PR DESCRIPTION
### Motivation

- Prevent expensive per-row measurements and paging logic that cause UI slowdowns when loading large shipment history datasets.
- Simplify history handling by removing the artificial capped-history and paging UX which complicated state and caused extra layout work.

### Description

- Changed vertical header resize mode from `QHeaderView.ResizeMode.ResizeToContents` to `QHeaderView.ResizeMode.Fixed` to avoid Qt measuring every row during inserts/updates. 
- Removed the history cap and paging constants and logic by returning the full sorted history in `_build_history_view`, removing toasts about capped data, and making `_history_effective_total` use the full history length. 
- Hid and disabled the legacy "Load More" button in the toolbar and `_sync_history_load_more_button` by default, and set initial toolbar history button visibility to `False`. 
- Kept chunked table population but adjusted finalization to call `_cancel_table_population(restore_table_state=False)` to avoid restoring intermediate state; removed an extra `setUpdatesEnabled(True)` in the chunked path. 

### Testing

- Ran the project's unit test suite (`pytest`) and static checks (`flake8`), and they completed successfully. 
- Performed an automated UI stress/load test that populates large history tables to validate performance and responsiveness, and it completed without UI freezes or exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb837d9d188331b079be2918d8f0e8)