### PR TITLE
Render Assembly Number as Code39 barcode in Sills PDF

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -5156,6 +5156,7 @@ class ModernShippingMainWindow(QMainWindow):
             cell_padding_vertical=8,
             cell_padding_horizontal=6,
             target_fill_ratio=0.92,
+            barcode_columns=[9],  # Assembly
         )
 
     def _print_table_to_pdf(
@@ -5167,6 +5168,7 @@ class ModernShippingMainWindow(QMainWindow):
         column_map: list[int],
         column_weights: list[float] | None = None,
         wrap_columns: list[int] | None = None,
+        barcode_columns: list[int] | None = None,
         page_size: tuple[float, float] = (8.5, 14),
         min_font_size: float = 9,
         min_title_font_size: float = 20,
@@ -5218,6 +5220,7 @@ class ModernShippingMainWindow(QMainWindow):
             from reportlab.lib import colors
             from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
             from reportlab.lib.units import inch
+            from reportlab.graphics.barcode import createBarcodeDrawing
 
             # Ruta por defecto en carpeta de Documentos
             docs_dir = QStandardPaths.writableLocation(
@@ -5345,6 +5348,13 @@ class ModernShippingMainWindow(QMainWindow):
                 )
 
                 wrapped_cols = set(range(len(headers))) if wrap_columns is None else set(wrap_columns)
+                barcode_cols = set(barcode_columns or [])
+
+                def to_code39_value(value: str) -> str:
+                    allowed = set("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ-. $/+%")
+                    normalized = (value or "").upper().strip()
+                    filtered = "".join(ch for ch in normalized if ch in allowed)
+                    return filtered or "BLANK"
 
                 def clamp_cell_text(cell_text, col_width):
                     """Limitar altura de celdas para evitar filas imposibles de dividir entre páginas."""
@@ -5382,6 +5392,23 @@ class ModernShippingMainWindow(QMainWindow):
                             if r == 0
                             else clamp_cell_text(cell_text, col_widths[c])
                         )
+
+                        if r > 0 and c in barcode_cols:
+                            barcode_value = to_code39_value(safe_text)
+                            barcode_width = max(16, col_widths[c] - (padding_h * 2))
+                            barcode_height = max(10, body_row_height - (padding_v * 2))
+                            barcode = createBarcodeDrawing(
+                                "Code39",
+                                value=barcode_value,
+                                barHeight=barcode_height,
+                                barWidth=0.012 * inch,
+                                humanReadable=True,
+                                quiet=True,
+                                width=barcode_width,
+                                height=barcode_height,
+                            )
+                            processed_row.append(barcode)
+                            continue
 
                         # Encabezados siempre en una sola línea; en body sólo hacen wrap
                         # las columnas explícitamente permitidas.


### PR DESCRIPTION
### Motivation
- Make the Assembly Number on the Sills Sheet printout scannable by rendering it as a Code39 (3 of 9) barcode in the generated PDF, matching the current Excel workflow that uses a Code39 font.

### Description
- Added an optional `barcode_columns` parameter to the generic PDF exporter `_print_table_to_pdf` and wired it into the Sills Sheet call to target the Assembly column (index 9).
- Imported `createBarcodeDrawing` from ReportLab and implemented `to_code39_value` to normalize Assembly values to a Code39-safe uppercase charset with a `BLANK` fallback.
- When a column is marked for barcode rendering the exporter creates a `Code39` barcode drawing with `humanReadable=True` and inserts it into the table cell instead of a Paragraph, sizing the barcode to the column and row metrics.
- Changed file: `ShippingClient/ui/main_window.py` to add the new parameter, barcode handling, and the Sills Sheet configuration.

### Testing
- Compiled the modified module with `python -m py_compile ShippingClient/ui/main_window.py` and the compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8b39332083319311ed8015c61218)