### PR TITLE
Improve visual emphasis for selected shipping tabs

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1699,28 +1699,33 @@ class ModernShippingMainWindow(QMainWindow):
                     border-radius: {RADIUS_MD}px;
                 }}
                 QTabBar::tab {{
-                    background: transparent;
+                    background: #F8FAFC;
                     color: #64748B;
-                    padding: 10px 18px;
+                    padding: 11px 18px;
                     margin-right: 6px;
-                    border-top-left-radius: 8px;
-                    border-top-right-radius: 8px;
+                    margin-bottom: 3px;
+                    border-radius: 10px;
                     font-weight: 500;
                     font-size: {sub_tab_font_size}px;
                     min-width: 92px;
-                    border: 1px solid transparent;
-                    border-bottom: 2px solid transparent;
+                    border: 1px solid #E2E8F0;
                 }}
                 QTabBar::tab:selected {{
-                    background: #EFF6FF;
-                    color: #1E3A8A;
-                    border: 1px solid #BFDBFE;
-                    border-bottom: 2px solid #2563EB;
+                    background: #DBEAFE;
+                    color: #1E40AF;
+                    border: 1px solid #93C5FD;
+                    border-bottom: 3px solid #2563EB;
+                    margin-bottom: 0px;
+                    padding-top: 12px;
                     font-weight: 700;
                 }}
                 QTabBar::tab:hover:!selected {{
-                    background: #F8FAFC;
+                    background: #F1F5F9;
                     color: #334155;
+                    border: 1px solid #CBD5E1;
+                }}
+                QTabBar::tab:!selected {{
+                    margin-top: 2px;
                 }}
             """
             )


### PR DESCRIPTION
### Motivation
- The internal Shipping subtabs had low visual contrast for the active state which made it easy to lose track of which tab is selected. 
- The goal was to increase perceived focus and reduce user confusion by strengthening the selected-tab visual styling and adding subtle elevation cues.

### Description
- Updated the sub-tab stylesheet in `ShippingClient/ui/main_window.py` to give unselected tabs a soft background and subtle border while making the selected tab use a stronger blue background, darker blue text, and a thicker bottom indicator. 
- Adjusted tab padding, margins and border-radius so the selected tab appears visually anchored and non-selected tabs sit slightly raised for clearer separation. 
- Improved hover state styling to provide clearer feedback and added a `QTabBar::tab:!selected` margin rule to help the active tab stand out. 
- This is a purely visual/UI refinement with no changes to application logic or behavior.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` which completed successfully. 
- No automated UI screenshot tests were available in this environment, so visual verification should be done in the application runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba25a68648331b403e5dda049a366)