### PR TITLE
Fix search returning empty results for valid shipment terms

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -4622,7 +4622,7 @@ class ModernShippingMainWindow(QMainWindow):
             return str(value or "").lower()
 
         lowered = search_text.lower()
-        for field in (
+        prioritized_fields = (
             "job_number",
             "job_name",
             "description",
@@ -4631,8 +4631,18 @@ class ModernShippingMainWindow(QMainWindow):
             "invoice_number",
             "qc_notes",
             "status",
-        ):
+            "address",
+            "week",
+        )
+        for field in prioritized_fields:
             if lowered in safe_lower(shipment.get(field)):
+                return True
+
+        # Fallback: permitir búsqueda por cualquier campo textual retornado por la API.
+        # Esto evita falsos "sin resultados" cuando el usuario busca por
+        # columnas nuevas o datos auxiliares no contemplados arriba.
+        for value in shipment.values():
+            if lowered in safe_lower(value):
                 return True
         return False
     


### PR DESCRIPTION
### Motivation
- Prevent the UI search from returning no results when users search by fields not previously considered by the matcher by expanding searchable fields and providing a robust fallback across all API-returned text values.

### Description
- Updated `shipment_matches_search` in `ShippingClient/ui/main_window.py` to add `address` and `week` to the prioritized search fields and to fall back to scanning every value in the `shipment` dict when prioritized fields don't match.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba56a2e04833188940fa2f28061b2)