### PR TITLE
fix: 'Production Updated' status missing from UI dropdowns

### DIFF
--- a/ShippingClient/ui/shipment_dialog.py
+++ b/ShippingClient/ui/shipment_dialog.py
@@ -233,6 +233,7 @@ class ModernShipmentDialog(QDialog):
             "Partial Release",
             "Final Release",
             "Rejected",
+            "Production Updated",
         ]
         self.status_combo.addItems(status_options)
         grid_layout.addWidget(self.status_combo, 2, 1)

--- a/ShippingClient/ui/status_delegate.py
+++ b/ShippingClient/ui/status_delegate.py
@@ -8,12 +8,13 @@ class StatusDelegate(QStyledItemDelegate):
         "partial_release": "Partial Release",
         "final_release": "Final Release",
         "rejected": "Rejected",
+        "prod_updated": "Production Updated",
     }
     CODE_MAP = {v: k for k, v in DISPLAY_MAP.items()}
 
     def createEditor(self, parent, option, index):
         editor = QComboBox(parent)
-        editor.addItems(["Partial Release", "Final Release", "Rejected"])
+        editor.addItems(["Partial Release", "Final Release", "Rejected", "Production Updated"])
         editor.setEditable(False)
         return editor
 


### PR DESCRIPTION
## Problemas corregidos

### 1. Status "Production Updated" no aparecía en los dropdowns
El backend soporta `prod_updated` pero no aparecía en ningún combo de la UI:
- ✅ Añadido al `ModernShipmentDialog` status combo
- ✅ Añadido al `StatusDelegate` (editor inline de la tabla)

### 2. Celdas de texto cortaban el contenido
Las celdas de campos largos (QC Notes, Shipping Notes, Description, etc.) no ajustaban su altura al texto envuelto, dejando el contenido cortado e ilegible.
- ✅ `sizeHint()` mejorado: calcula altura real usando el ancho de columna, márgenes del estilo, padding y fuente
- ✅ Padding horizontal (8px) y vertical (6px) separados
- ✅ Altura mínima de fila para legibilidad
- ✅ `_ROW_EXTRA_HEIGHT` aumentado de 6→10
- ✅ `_refresh_visible_row_heights()` se llama siempre durante la finalización de carga

### 3. Editor inline gigante
Al hacer doble-click en una celda de texto, se abría un `QLineEdit` que ocupaba todo el ancho de la columna — en columnas anchas se expandía por toda la pantalla.
- ✅ Nuevo `createEditor()` → usa `QPlainTextEdit` (multilínea) en vez de `QLineEdit`
- ✅ Nuevo `updateEditorGeometry()` → altura máxima 160px, ancho mínimo 280px, siempre dentro del viewport
- ✅ El editor se adapta al contenido: alto para texto envuelto, pero nunca desborda la pantalla
- ✅ Tab mueve el foco en vez de insertar tabs

---

3 archivos, 86 líneas añadidas, 11 eliminadas.