### PR TITLE
fix: text cells cutting off + giant inline editor

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -730,8 +730,11 @@ class StatusChipDelegate(QStyledItemDelegate):
 class WrapAnywhereDelegate(QStyledItemDelegate):
     """Custom delegate that allows long text chunks to wrap in table cells."""
 
-    _PADDING = 12
+    _PADDING_H = 8
+    _PADDING_V = 6
     _MIN_HINT_WIDTH = 180
+    _EDITOR_MAX_HEIGHT = 160
+    _EDITOR_MIN_WIDTH = 280
     _SELECTED_TEXT_COLOR = QColor("#0F2A57")
 
     def paint(self, painter, option, index):  # type: ignore[override]
@@ -754,7 +757,7 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
         else:
             painter.setPen(opt.palette.text().color())
         painter.drawText(
-            text_rect.adjusted(2, 2, -2, -2),
+            text_rect.adjusted(self._PADDING_H, self._PADDING_V, -self._PADDING_H, -self._PADDING_V),
             Qt.AlignmentFlag.AlignLeft
             | Qt.AlignmentFlag.AlignTop
             | Qt.TextFlag.TextWordWrap
@@ -768,20 +771,86 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
         if not text:
             return super().sizeHint(option, index)
 
-        width = option.rect.width() - self._PADDING
-        if width <= 0:
-            width = self._MIN_HINT_WIDTH
+        col_width = option.rect.width()
+        if col_width <= 0:
+            col_width = self._MIN_HINT_WIDTH
 
-        bounds = option.fontMetrics.boundingRect(
-            QRect(0, 0, width, 10000),
+        # Account for style padding and sub-element margins
+        widget = option.widget
+        style = widget.style() if widget else QApplication.style()
+        text_margin = style.pixelMetric(QStyle.PixelMetric.PM_FocusFrameHMargin, option, widget) + 2
+        icon_width = 0
+        if option.features & QStyleOptionViewItem.ViewItemFeature.HasDecoration:
+            icon_width = option.decorationSize.width() + 4
+
+        available_width = col_width - self._PADDING_H * 2 - text_margin - icon_width
+        if available_width <= 0:
+            available_width = self._MIN_HINT_WIDTH
+
+        fm = option.fontMetrics
+        bounds = fm.boundingRect(
+            QRect(0, 0, available_width, 10000),
             Qt.AlignmentFlag.AlignLeft | Qt.TextFlag.TextWordWrap | Qt.TextFlag.TextWrapAnywhere,
             text,
         )
-        return QSize(bounds.width() + self._PADDING, bounds.height() + self._PADDING)
+        height = bounds.height() + self._PADDING_V * 2 + text_margin
+        min_h = fm.lineSpacing() + self._PADDING_V * 2 + 4
+        return QSize(bounds.width() + self._PADDING_H * 2 + text_margin, max(height, min_h))
+
+    def createEditor(self, parent, option, index):  # type: ignore[override]
+        from PyQt6.QtWidgets import QPlainTextEdit
+        editor = QPlainTextEdit(parent)
+        editor.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        editor.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        editor.setTabChangesFocus(True)
+        return editor
+
+    def updateEditorGeometry(self, editor, option, index):  # type: ignore[override]
+        table = option.widget
+        if table is not None:
+            viewport_height = table.viewport().height()
+            viewport_width = table.viewport().width()
+        else:
+            viewport_height = 600
+            viewport_width = 800
+
+        cell_rect = option.rect
+        editor_width = max(self._EDITOR_MIN_WIDTH, min(cell_rect.width(), viewport_width - 20))
+        text = str(index.data(Qt.ItemDataRole.DisplayRole) or "")
+        if text:
+            fm = editor.fontMetrics()
+            lines = text.count('\n') + 1
+            words = len(text) / max(1, editor_width / max(1, fm.averageCharWidth()))
+            needed_lines = max(lines, int(words) + 1)
+            content_height = needed_lines * fm.lineSpacing() + 16
+        else:
+            content_height = fm.lineSpacing() * 3 + 16
+
+        editor_height = min(content_height, self._EDITOR_MAX_HEIGHT)
+        editor_height = max(editor_height, 60)
+
+        top = cell_rect.top()
+        if top + editor_height > viewport_height:
+            top = max(0, viewport_height - editor_height - 5)
+
+        left = max(2, cell_rect.left())
+        if left + editor_width > viewport_width:
+            left = max(2, viewport_width - editor_width - 5)
+
+        editor.setGeometry(left, top, editor_width, editor_height)
+
+    def setEditorData(self, editor, index):  # type: ignore[override]
+        text = str(index.data(Qt.ItemDataRole.EditRole) or "")
+        editor.setPlainText(text)
+
+    def setModelData(self, editor, model, index):  # type: ignore[override]
+        text = editor.toPlainText()
+        model.setData(index, text, Qt.ItemDataRole.EditRole)
+        model.setData(index, text, Qt.ItemDataRole.DisplayRole)
 
 
 class ModernShippingMainWindow(QMainWindow):
-    _ROW_EXTRA_HEIGHT = 6
+    _ROW_EXTRA_HEIGHT = 10
     _HEAVY_LAYOUT_ROW_THRESHOLD = 1000
     _HISTORY_CHUNK_THRESHOLD = 250
     DEFAULT_TABLE_COLUMNS = [
@@ -4559,9 +4628,9 @@ class ModernShippingMainWindow(QMainWindow):
 
         table.setUpdatesEnabled(True)
         table.blockSignals(False)
+        self._refresh_visible_row_heights(table)
         if run_expensive_layout:
             self._ensure_columns_fit_content(table)
-            self._refresh_visible_row_heights(table)
         self.refresh_pinned_columns(table, table_name)
         self.updating_table = False
         if started_at is not None:


### PR DESCRIPTION
## Problema

### 1. Celdas de texto cortan el contenido
Las celdas de campos largos (QC Notes, Shipping Notes, Description, etc.) no ajustaban su altura al texto envuelto — el contenido quedaba cortado horizontal y verticalmente, ilegible.

**Causa:** `WrapAnywhereDelegate.sizeHint()` no consideraba los márgenes reales del estilo (`PM_FocusFrameHMargin`), el ancho del icono, ni la diferencia entre padding horizontal y vertical.

### 2. Editor inline se expande por toda la pantalla
Al hacer doble-click en una celda de texto, Qt creaba un `QLineEdit` que heredaba todo el ancho de la columna — en columnas stretch, ocupaba pantalla completa.

---

## Solucion

### Texto ya no se corta
- ✅ `sizeHint()` recalculado: ancho disponible = ancho columna − márgenes estilo − icono − padding H
- ✅ `boundingRect()` ahora usa el ancho real disponible para calcular lineas envueltas
- ✅ Padding separado: `_PADDING_H = 8`, `_PADDING_V = 6`
- ✅ Altura minima de fila = `lineSpacing + padding + 4`
- ✅ `_ROW_EXTRA_HEIGHT` aumentado 6 → 10
- ✅ `_refresh_visible_row_heights()` se llama **siempre** al finalizar carga (antes solo con layout caro)

### Editor ya no es gigante
- ✅ Nuevo `createEditor()` → `QPlainTextEdit` multilinea en vez de `QLineEdit`
- ✅ Nuevo `updateEditorGeometry()` → altura max 160px, ancho min 280px, siempre dentro del viewport
- ✅ Altura se adapta al contenido pero nunca desborda la pantalla
- ✅ Tab mueve el foco al siguiente campo, no inserta tabs
- ✅ Scrollbars solo si el contenido excede el area visible

---

1 archivo, 79 lineas añadidas, 10 eliminadas.