### PR TITLE
Fix empty shipping cell editor crash

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1,4 +1,4 @@
-﻿# ui/main_window.py - Ventana principal con diseño profesional
+# ui/main_window.py - Ventana principal con diseño profesional
 import csv
 import json
 import time
@@ -816,9 +816,9 @@ class WrapAnywhereDelegate(QStyledItemDelegate):
 
         cell_rect = option.rect
         editor_width = max(self._EDITOR_MIN_WIDTH, min(cell_rect.width(), viewport_width - 20))
+        fm = editor.fontMetrics()
         text = str(index.data(Qt.ItemDataRole.DisplayRole) or "")
         if text:
-            fm = editor.fontMetrics()
             lines = text.count('\n') + 1
             words = len(text) / max(1, editor_width / max(1, fm.averageCharWidth()))
             needed_lines = max(lines, int(words) + 1)


### PR DESCRIPTION
### Motivation
- Prevent an `UnboundLocalError` when opening the inline editor for empty cells in the Shipping tab by ensuring font metrics are available before sizing logic runs.

### Description
- Initialize `fm = editor.fontMetrics()` before checking the cell text in `WrapAnywhereDelegate.updateEditorGeometry` so the empty-cell branch does not reference an unassigned local variable (file: `ShippingClient/ui/main_window.py`).

### Testing
- Compiled the module with `python -m compileall ShippingClient/ui/main_window.py` which succeeded, and ran `pytest -q` which failed during collection due to missing environment dependencies (`fastapi`, `requests`) and missing `PyQt6` in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c3654a888331a24c70a09cd24998)