### PR TITLE
Add per-user permissions and Permissions tab

### DIFF
--- a/ShippingClient/core/api_client.py
+++ b/ShippingClient/core/api_client.py
@@ -198,6 +198,15 @@ class RobustApiClient:
         """Obtener configuración de conexiones externas."""
         return self.get("/settings/connections")
 
+    def get_my_permissions(self) -> ApiResponse:
+        return self.get("/permissions/me")
+
+    def get_user_permissions(self, user_id: int) -> ApiResponse:
+        return self.get(f"/users/{user_id}/permissions")
+
+    def update_user_permissions(self, user_id: int, permissions_data: Dict) -> ApiResponse:
+        return self.put(f"/users/{user_id}/permissions", data=permissions_data)
+
     def update_fedex_settings(self, enabled: bool, api_key: str, secret_key: str, base_url: str = "") -> ApiResponse:
         """Guardar configuración de FedEx."""
         payload = {

--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -49,6 +49,7 @@ from PyQt6.QtWidgets import (
     QDateEdit,
     QStyleOptionViewItem,
     QStyledItemDelegate,
+    QGraphicsBlurEffect,
 )
 from PyQt6.QtCore import (
     Qt,
@@ -177,12 +178,14 @@ class SillDialog(QDialog):
         parent: Optional[QWidget] = None,
         sill_data: Optional[dict] = None,
         die_database: Optional[list[dict]] = None,
+        editable_fields: Optional[set[str]] = None,
     ):
         super().__init__(parent)
         self.setWindowTitle("Sill")
         self.setMinimumWidth(520)
         self._edit_data = sill_data or {}
         self._die_database = die_database or []
+        self._editable_fields = editable_fields
         self._die_lookup = {
             str(item.get("die_number", "")).strip().lower(): item
             for item in self._die_database
@@ -227,6 +230,8 @@ class SillDialog(QDialog):
                 input_widget.setDate(parsed_date if parsed_date.isValid() else QDate.currentDate())
             else:
                 input_widget.setText(value)
+            if self._editable_fields is not None and key not in self._editable_fields:
+                input_widget.setEnabled(False)
             form.addRow(QLabel(label), input_widget)
             self.inputs[key] = input_widget
             if key in first_section_fields and index + 1 < len(self.FIELDS):
@@ -949,6 +954,7 @@ class ModernShippingMainWindow(QMainWindow):
 
         self.is_admin = self.user_info.get("role") == "admin"
         self.read_only = self.user_info.get("role") == "read"
+        self.user_permissions = self._load_current_user_permissions()
 
         parsed_server = urlparse(get_server_url())
         self.server_host = parsed_server.hostname or parsed_server.netloc or get_server_url()
@@ -1070,7 +1076,8 @@ class ModernShippingMainWindow(QMainWindow):
             self.setup_websocket()
 
             # Cargar datos en background
-            self.load_shipments_async()
+            if self._module_can_view("shipping_schedule"):
+                self.load_shipments_async()
             
             # Timer para actualizar status
             self.status_timer = QTimer()
@@ -1083,6 +1090,50 @@ class ModernShippingMainWindow(QMainWindow):
             import traceback
             traceback.print_exc()
     
+    def _default_permissions_payload(self) -> dict:
+        can_write = self.user_info.get("role") in {"write", "admin"}
+        return {
+            "modules": {
+                "shipping_schedule": {
+                    "can_view": True,
+                    "columns": {key: can_write for key in self.TABLE_COLUMN_KEYS if key != "job_number"},
+                },
+                "sills": {
+                    "can_view": True,
+                    "columns": {key: can_write for key in [field[0] for field in SillDialog.FIELDS]},
+                },
+                "sills_database": {
+                    "can_view": True,
+                    "columns": {"sills_database": can_write},
+                },
+            }
+        }
+
+    def _load_current_user_permissions(self) -> dict:
+        if self.user_info.get("role") == "admin":
+            return self._default_permissions_payload()
+        response = self.api_client.get_my_permissions()
+        if response.is_success():
+            return response.get_data() or self._default_permissions_payload()
+        print(f"Unable to load permissions: {response.get_error()}")
+        return self._default_permissions_payload()
+
+    def _module_can_view(self, module_key: str) -> bool:
+        if self.is_admin:
+            return True
+        return bool(self.user_permissions.get("modules", {}).get(module_key, {}).get("can_view", True))
+
+    def _column_can_write(self, module_key: str, column_key: str) -> bool:
+        if self.is_admin:
+            return True
+        if self.user_info.get("role") not in {"write", "admin"}:
+            return False
+        module = self.user_permissions.get("modules", {}).get(module_key, {})
+        return bool(module.get("can_view", True) and module.get("columns", {}).get(column_key, False))
+
+    def _can_write_all(self, module_key: str, column_keys: list[str]) -> bool:
+        return all(self._column_can_write(module_key, key) for key in column_keys)
+
     def setup_ui(self):
         """Configurar interfaz de usuario profesional"""
         try:
@@ -1830,10 +1881,33 @@ class ModernShippingMainWindow(QMainWindow):
         self.main_tab_widget.addTab(shipping_page, "Shipping")
         self.sills_page = self.create_sills_module_page()
         self.main_tab_widget.addTab(self.sills_page, "Sills")
+        self._apply_module_access_state()
         self.main_tab_widget.currentChanged.connect(self.on_main_tab_changed)
 
         tabs_layout.addWidget(self.main_tab_widget)
         layout.addWidget(tabs_container)
+
+    def _apply_module_access_state(self):
+        access_map = {0: ("shipping_schedule", "Shipping"), 1: ("sills", "Sills")}
+        for index, (module_key, label) in access_map.items():
+            if index >= self.main_tab_widget.count():
+                continue
+            page = self.main_tab_widget.widget(index)
+            has_access = self._module_can_view(module_key)
+            self.main_tab_widget.setTabEnabled(index, has_access)
+            self.main_tab_widget.setTabToolTip(
+                index,
+                "" if has_access else f"{label} is visible but blocked by permissions.",
+            )
+            if page is not None:
+                if has_access:
+                    page.setGraphicsEffect(None)
+                    page.setEnabled(True)
+                else:
+                    blur = QGraphicsBlurEffect(page)
+                    blur.setBlurRadius(8)
+                    page.setGraphicsEffect(blur)
+                    page.setEnabled(False)
 
     def create_shipping_logs_page(self):
         logs_page = QWidget()
@@ -2222,13 +2296,29 @@ class ModernShippingMainWindow(QMainWindow):
         self.sills_die_refresh_btn.clicked.connect(self.load_sill_dies)
         self.sills_die_table.itemDoubleClicked.connect(lambda _: self.open_edit_sill_die_dialog())
         tabs.currentChanged.connect(self._on_sills_tab_changed)
+        self._apply_sills_permission_state()
 
         self.load_sills()
         self.load_sill_dies()
         self.refresh_sills_dashboard()
         return page
 
+    def _apply_sills_permission_state(self):
+        can_edit_sills = self._can_write_all("sills", [field[0] for field in SillDialog.FIELDS])
+        for widget_name in ("sills_add_btn", "sills_edit_btn", "sills_delete_btn"):
+            widget = getattr(self, widget_name, None)
+            if widget is not None:
+                widget.setEnabled(can_edit_sills)
+        can_edit_dies = self._column_can_write("sills_database", "sills_database")
+        for widget_name in ("sills_die_add_btn", "sills_die_edit_btn", "sills_die_delete_btn"):
+            widget = getattr(self, widget_name, None)
+            if widget is not None:
+                widget.setEnabled(can_edit_dies)
+
     def load_sills(self):
+        if not self._module_can_view("sills"):
+            self.sills = []
+            return
         response = self.api_client.get_sills()
         if not response.is_success():
             self.show_error(response.get_error() or "Failed to load sills.")
@@ -2303,6 +2393,9 @@ class ModernShippingMainWindow(QMainWindow):
         self.sills_dashboard_cards["dies_total"].setText(str(len(self.sill_dies or [])))
 
     def load_sill_dies(self):
+        if not self._module_can_view("sills_database"):
+            self.sill_dies = []
+            return
         response = self.api_client.get_sill_dies()
         if not response.is_success():
             self.show_error(response.get_error() or "Failed to load die database.")
@@ -2339,8 +2432,8 @@ class ModernShippingMainWindow(QMainWindow):
         return self.sill_dies[row]
 
     def open_add_sill_dialog(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        if not self._can_write_all("sills", [field[0] for field in SillDialog.FIELDS]):
+            self.show_error("You do not have permission to create sills.")
             return
         dialog = SillDialog(self, die_database=self.sill_dies)
         if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -2352,16 +2445,28 @@ class ModernShippingMainWindow(QMainWindow):
                 self.show_error(response.get_error() or "Failed to create sill.")
 
     def open_edit_sill_dialog(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        editable_fields = {
+            field_key
+            for field_key, _label in SillDialog.FIELDS
+            if self._column_can_write("sills", field_key)
+        }
+        if not editable_fields:
+            self.show_error("You do not have permission to edit sill fields.")
             return
         sill = self._selected_sill()
         if not sill:
             self.show_error("Select a sill first.")
             return
-        dialog = SillDialog(self, sill_data=sill, die_database=self.sill_dies)
+        dialog = SillDialog(self, sill_data=sill, die_database=self.sill_dies, editable_fields=editable_fields)
         if dialog.exec() == QDialog.DialogCode.Accepted:
-            response = self.api_client.update_sill(int(sill["id"]), dialog.get_payload())
+            payload = {
+                key: value
+                for key, value in dialog.get_payload().items()
+                if key in editable_fields and str(value) != str(sill.get(key, ""))
+            }
+            if not payload:
+                return
+            response = self.api_client.update_sill(int(sill["id"]), payload)
             if response.is_success():
                 self.load_sills()
                 self.load_sills_logs()
@@ -2369,8 +2474,8 @@ class ModernShippingMainWindow(QMainWindow):
                 self.show_error(response.get_error() or "Failed to update sill.")
 
     def delete_sill(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        if not self._can_write_all("sills", [field[0] for field in SillDialog.FIELDS]):
+            self.show_error("You do not have permission to delete sills.")
             return
         sill = self._selected_sill()
         if not sill:
@@ -2387,8 +2492,8 @@ class ModernShippingMainWindow(QMainWindow):
             self.show_error(response.get_error() or "Failed to delete sill.")
 
     def open_add_sill_die_dialog(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        if not self._column_can_write("sills_database", "sills_database"):
+            self.show_error("You do not have permission to edit the Sills DB.")
             return
         dialog = SillDieDialog(self)
         if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -2399,8 +2504,8 @@ class ModernShippingMainWindow(QMainWindow):
                 self.show_error(response.get_error() or "Failed to create die.")
 
     def open_edit_sill_die_dialog(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        if not self._column_can_write("sills_database", "sills_database"):
+            self.show_error("You do not have permission to edit the Sills DB.")
             return
         die_data = self._selected_sill_die()
         if not die_data:
@@ -2415,8 +2520,8 @@ class ModernShippingMainWindow(QMainWindow):
                 self.show_error(response.get_error() or "Failed to update die.")
 
     def delete_sill_die(self):
-        if self.read_only:
-            self.show_error("You only have read permissions.")
+        if not self._column_can_write("sills_database", "sills_database"):
+            self.show_error("You do not have permission to edit the Sills DB.")
             return
         die_data = self._selected_sill_die()
         if not die_data:
@@ -2999,10 +3104,11 @@ class ModernShippingMainWindow(QMainWindow):
                 "can_delete": False,
                 "can_change_status": False,
             }
+        can_write_shipping = self._can_write_all("shipping_schedule", [key for key in self.TABLE_COLUMN_KEYS if key != "job_number"])
         return {
-            "can_edit": True,
-            "can_delete": True,
-            "can_change_status": True,
+            "can_edit": can_write_shipping,
+            "can_delete": can_write_shipping,
+            "can_change_status": can_write_shipping,
         }
 
     def _get_module_policy(self, module_id: str) -> dict[str, bool]:
@@ -4699,7 +4805,10 @@ class ModernShippingMainWindow(QMainWindow):
                     shipment['version'] = 1
                 # job number no editable
                 item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
-            elif col in self.CENTER_ALIGN_COLUMNS:
+            elif not self._column_can_write("shipping_schedule", key):
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+
+            if col in self.CENTER_ALIGN_COLUMNS:
                 item.setTextAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignCenter)
             elif col in self.RIGHT_ALIGN_COLUMNS:
                 item.setTextAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignRight)
@@ -5017,6 +5126,9 @@ class ModernShippingMainWindow(QMainWindow):
         field = self.column_field_map.get(col)
 
         if field is None:
+            return
+        if not self._column_can_write("shipping_schedule", field):
+            self.show_error("You do not have write permission for this column.")
             return
 
         job_item = table.item(row, 0)

--- a/ShippingClient/ui/settings_dialog.py
+++ b/ShippingClient/ui/settings_dialog.py
@@ -12,6 +12,10 @@ from PyQt6.QtWidgets import (
     QCheckBox,
     QFrame,
     QScrollArea,
+    QTableWidget,
+    QTableWidgetItem,
+    QHeaderView,
+    QAbstractItemView,
 )
 from PyQt6.QtGui import QFont
 from PyQt6.QtCore import Qt
@@ -52,6 +56,10 @@ class SettingsDialog(QDialog):
             base_url=self.settings_mgr.get_server_url(),
             token=self.token,
         )
+        self.permission_users = []
+        self.permission_checkboxes = {}
+        self.permission_module_checkboxes = {}
+
 
         self.setWindowTitle("Settings")
         self.setModal(True)
@@ -92,6 +100,9 @@ class SettingsDialog(QDialog):
             self.users_tab = QWidget()
             self._setup_users_tab()
             self.tabs.addTab(self.users_tab, "Users")
+            self.permissions_tab = QWidget()
+            self._setup_permissions_tab()
+            self.tabs.addTab(self.permissions_tab, "Permissions")
 
         content_wrapper = QFrame()
         content_wrapper.setObjectName("contentWrapper")
@@ -296,6 +307,204 @@ class SettingsDialog(QDialog):
         self.user_management = UserManagementWidget(self.token, parent=self.users_tab)
         layout.addWidget(self.user_management)
 
+    def _setup_permissions_tab(self):
+        layout = QVBoxLayout(self.permissions_tab)
+        layout.setContentsMargins(SPACE_16, SPACE_16, SPACE_16, SPACE_12)
+        layout.setSpacing(SPACE_16)
+
+        selector_row = QHBoxLayout()
+        selector_label = QLabel("User")
+        apply_scaled_font(selector_label, offset=1, weight=QFont.Weight.Medium)
+        self.permissions_user_combo = ModernComboBox()
+        self.permissions_user_combo.currentIndexChanged.connect(self._load_selected_user_permissions)
+        selector_row.addWidget(selector_label)
+        selector_row.addWidget(self.permissions_user_combo, 1)
+        layout.addLayout(selector_row)
+
+        self.permissions_notice = QLabel("Admins always have full access. Only admins can save changes in this tab.")
+        self.permissions_notice.setStyleSheet(f"color: {COLOR_TEXT_SECONDARY};")
+        apply_scaled_font(self.permissions_notice, offset=-1)
+        layout.addWidget(self.permissions_notice)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        content = QWidget()
+        content_layout = QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(SPACE_16)
+
+        self._add_permission_section(
+            content_layout,
+            module_key="shipping_schedule",
+            title="Shipping Schedule",
+            rows=[
+                ("job_name", "Job Name"),
+                ("description", "Description"),
+                ("qc_release", "QC Rel."),
+                ("qc_notes", "QC Notes"),
+                ("created", "Crated"),
+                ("ship_plan", "Ship Plan"),
+                ("shipped", "Shipped"),
+                ("invoice_number", "Invoice"),
+                ("tracking_number", "Tracking #"),
+                ("address", "Address"),
+                ("shipping_notes", "Shipping Notes"),
+            ],
+        )
+        self._add_permission_section(
+            content_layout,
+            module_key="sills",
+            title="Sills",
+            rows=[
+                ("material", "Material"),
+                ("dimension", "Dimension"),
+                ("location", "Location"),
+                ("die_number", "Die #"),
+                ("type", "Type"),
+                ("speed", "Speed"),
+                ("width", "Width"),
+                ("sales_order", "Sales Order"),
+                ("work_order", "Work Order"),
+                ("assembly_number", "Assembly Number"),
+                ("description", "Description"),
+                ("qty", "Qty"),
+                ("dimension_needed", "Dimension Needed"),
+                ("notes", "Notes"),
+                ("week_to_print", "Week to Print"),
+            ],
+            extra_rows=[("sills_database", "Sills DB (all fields)")],
+        )
+        content_layout.addStretch()
+        scroll.setWidget(content)
+        layout.addWidget(scroll, 1)
+
+    def _add_permission_section(self, parent_layout, module_key: str, title: str, rows, extra_rows=None):
+        section, content_layout = self._create_connection_section(title)
+        header = QHBoxLayout()
+        header.setContentsMargins(0, 0, 0, 0)
+        module_checkbox = QCheckBox("Visible")
+        module_checkbox.setEnabled(self.is_admin)
+        self.permission_module_checkboxes[module_key] = module_checkbox
+        header.addWidget(QLabel("Module access"))
+        header.addStretch()
+        header.addWidget(module_checkbox)
+        content_layout.addLayout(header)
+
+        table = QTableWidget(0, 2)
+        table.setHorizontalHeaderLabels(["Column", "Write"])
+        table.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.Stretch)
+        table.horizontalHeader().setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        table.verticalHeader().setVisible(False)
+        table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+        table.setSelectionMode(QAbstractItemView.SelectionMode.NoSelection)
+        table.setAlternatingRowColors(True)
+        self.permission_checkboxes[module_key] = {}
+        for key, label in rows:
+            self._add_permission_row(table, module_key, key, label)
+        table.resizeRowsToContents()
+        content_layout.addWidget(table)
+
+        if extra_rows:
+            extra_label = QLabel("Sub tabs")
+            apply_scaled_font(extra_label, offset=1, weight=QFont.Weight.Medium)
+            content_layout.addWidget(extra_label)
+            for key, label in extra_rows:
+                row = QHBoxLayout()
+                row.setContentsMargins(0, 0, 0, 0)
+                checkbox = QCheckBox("Write")
+                checkbox.setEnabled(self.is_admin)
+                self.permission_checkboxes[key] = {key: checkbox}
+                row.addWidget(QLabel(label))
+                row.addStretch()
+                row.addWidget(checkbox)
+                content_layout.addLayout(row)
+
+        parent_layout.addWidget(section)
+
+    def _add_permission_row(self, table, module_key: str, column_key: str, label: str):
+        row = table.rowCount()
+        table.insertRow(row)
+        label_item = QTableWidgetItem(label)
+        label_item.setFlags(label_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+        table.setItem(row, 0, label_item)
+        checkbox = QCheckBox()
+        checkbox.setEnabled(self.is_admin)
+        cell = QWidget()
+        cell_layout = QHBoxLayout(cell)
+        cell_layout.setContentsMargins(0, 0, 0, 0)
+        cell_layout.addStretch()
+        cell_layout.addWidget(checkbox)
+        cell_layout.addStretch()
+        table.setCellWidget(row, 1, cell)
+        self.permission_checkboxes[module_key][column_key] = checkbox
+
+    def _load_permission_users(self):
+        if not self.is_admin or not hasattr(self, "permissions_user_combo"):
+            return
+        response = self.api_client.get("/users")
+        if not response.is_success():
+            QMessageBox.warning(self, "Permissions", response.get_error() or "Failed to load users")
+            return
+        self.permission_users = response.get_data() or []
+        self.permissions_user_combo.blockSignals(True)
+        self.permissions_user_combo.clear()
+        for user in self.permission_users:
+            self.permissions_user_combo.addItem(f"{user.get('username')} ({user.get('role')})", user.get("id"))
+        self.permissions_user_combo.blockSignals(False)
+        self._load_selected_user_permissions()
+
+    def _load_selected_user_permissions(self):
+        if not hasattr(self, "permissions_user_combo"):
+            return
+        user_id = self.permissions_user_combo.currentData()
+        if not user_id:
+            return
+        response = self.api_client.get_user_permissions(int(user_id))
+        if not response.is_success():
+            QMessageBox.warning(self, "Permissions", response.get_error() or "Failed to load permissions")
+            return
+        self._apply_permissions_payload(response.get_data() or {})
+
+    def _apply_permissions_payload(self, payload):
+        modules = (payload or {}).get("modules", {})
+        for module_key, checkbox in self.permission_module_checkboxes.items():
+            checkbox.setChecked(bool(modules.get(module_key, {}).get("can_view", True)))
+        for module_key, checkboxes in self.permission_checkboxes.items():
+            if module_key == "sills_database":
+                columns = modules.get("sills_database", {}).get("columns", {})
+            else:
+                columns = modules.get(module_key, {}).get("columns", {})
+            for column_key, checkbox in checkboxes.items():
+                checkbox.setChecked(bool(columns.get(column_key, False)))
+
+    def _collect_permissions_payload(self):
+        modules = {}
+        for module_key, checkbox in self.permission_module_checkboxes.items():
+            columns = {
+                column_key: column_checkbox.isChecked()
+                for column_key, column_checkbox in self.permission_checkboxes.get(module_key, {}).items()
+            }
+            modules[module_key] = {"can_view": checkbox.isChecked(), "columns": columns}
+        sills_db_checkbox = self.permission_checkboxes.get("sills_database", {}).get("sills_database")
+        modules["sills_database"] = {
+            "can_view": self.permission_module_checkboxes.get("sills", QCheckBox()).isChecked(),
+            "columns": {"sills_database": bool(sills_db_checkbox and sills_db_checkbox.isChecked())},
+        }
+        return {"modules": modules}
+
+    def _save_permissions(self) -> bool:
+        if not self.is_admin or not hasattr(self, "permissions_user_combo"):
+            return True
+        user_id = self.permissions_user_combo.currentData()
+        if not user_id:
+            return True
+        response = self.api_client.update_user_permissions(int(user_id), self._collect_permissions_payload())
+        if not response.is_success():
+            QMessageBox.warning(self, "Permissions", response.get_error() or "Failed to save permissions")
+            return False
+        return True
+
     def _apply_dialog_style(self):
         self.setStyleSheet(
             f"""
@@ -426,6 +635,7 @@ class SettingsDialog(QDialog):
                 self.fedex_secret_key_edit.setPlaceholderText("********")
         else:
             self.fedex_enabled.setChecked(False)
+        self._load_permission_users()
 
     def load_mie_trak_databases(self):
         server = self.mie_trak_server_edit.text().strip() or "GUNDMAIN"
@@ -502,6 +712,9 @@ class SettingsDialog(QDialog):
             response = self.api_client.update_fedex_settings(enabled, fedex_api_key, fedex_secret_key, fedex_base_url)
             if not response.is_success():
                 QMessageBox.warning(self, "Error", response.get_error() or "Failed to save FedEx settings")
+                return
+
+            if not self._save_permissions():
                 return
 
         app = QApplication.instance()

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -1,4 +1,4 @@
-﻿# main.py - Servidor principal FastAPI
+# main.py - Servidor principal FastAPI
 from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
@@ -13,10 +13,49 @@ from sqlalchemy.orm.exc import StaleDataError
 
 # Imports locales
 from database import get_db, create_tables, create_admin_user
-from models import User, Shipment, AuditLog, ShippingLog, AppConnectionSettings, Sill, SillLog, SillDieDatabase
+from models import User, Shipment, AuditLog, ShippingLog, AppConnectionSettings, Sill, SillLog, SillDieDatabase, UserPermission
 from auth import authenticate_user, create_access_token, get_current_user, get_current_admin_user, Token, UserLogin, UserCreate
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from fedex_service import FedExService
+
+
+
+SHIPPING_PERMISSION_COLUMNS = [
+    "job_name",
+    "description",
+    "qc_release",
+    "qc_notes",
+    "created",
+    "ship_plan",
+    "shipped",
+    "invoice_number",
+    "tracking_number",
+    "address",
+    "shipping_notes",
+]
+SILLS_PERMISSION_COLUMNS = [
+    "material",
+    "dimension",
+    "location",
+    "die_number",
+    "type",
+    "speed",
+    "width",
+    "sales_order",
+    "work_order",
+    "assembly_number",
+    "description",
+    "qty",
+    "dimension_needed",
+    "notes",
+    "week_to_print",
+]
+SILLS_DIE_PERMISSION_KEY = "sills_database"
+PERMISSION_MODULES = {
+    "shipping_schedule": set(SHIPPING_PERMISSION_COLUMNS),
+    "sills": set(SILLS_PERMISSION_COLUMNS),
+    "sills_database": {SILLS_DIE_PERMISSION_KEY},
+}
 
 # Crear app FastAPI
 app = FastAPI(title="Shipping Schedule API", version="1.0.0")
@@ -131,6 +170,15 @@ class UserResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class ModulePermissionUpdate(BaseModel):
+    can_view: bool = True
+    columns: dict[str, bool] = Field(default_factory=dict)
+
+
+class UserPermissionsUpdate(BaseModel):
+    modules: dict[str, ModulePermissionUpdate] = Field(default_factory=dict)
 
 
 class FedExConnectionSettingsUpdate(BaseModel):
@@ -337,6 +385,115 @@ def _append_sills_logs(
             )
         )
 
+
+def _admin_permissions_payload() -> dict:
+    return {
+        "modules": {
+            "shipping_schedule": {
+                "can_view": True,
+                "columns": {column: True for column in SHIPPING_PERMISSION_COLUMNS},
+            },
+            "sills": {
+                "can_view": True,
+                "columns": {column: True for column in SILLS_PERMISSION_COLUMNS},
+            },
+            "sills_database": {
+                "can_view": True,
+                "columns": {SILLS_DIE_PERMISSION_KEY: True},
+            },
+        }
+    }
+
+
+def _get_user_permissions_payload(db: Session, user: User) -> dict:
+    if user.role == "admin":
+        return _admin_permissions_payload()
+
+    payload = {
+        "modules": {
+            "shipping_schedule": {
+                "can_view": True,
+                "columns": {column: user.role == "write" for column in SHIPPING_PERMISSION_COLUMNS},
+            },
+            "sills": {
+                "can_view": True,
+                "columns": {column: user.role == "write" for column in SILLS_PERMISSION_COLUMNS},
+            },
+            "sills_database": {
+                "can_view": True,
+                "columns": {SILLS_DIE_PERMISSION_KEY: user.role == "write"},
+            },
+        }
+    }
+    records = db.query(UserPermission).filter(UserPermission.user_id == user.id).all()
+    for record in records:
+        module_payload = payload["modules"].get(record.module)
+        if module_payload is None:
+            continue
+        if not record.column_key:
+            module_payload["can_view"] = bool(record.can_view)
+        elif record.column_key in module_payload["columns"]:
+            module_payload["columns"][record.column_key] = bool(record.can_write)
+    return payload
+
+
+def _upsert_permission(
+    db: Session,
+    *,
+    target_user_id: int,
+    module: str,
+    column_key: str,
+    can_view: bool,
+    can_write: bool,
+    updated_by: int,
+):
+    record = (
+        db.query(UserPermission)
+        .filter(
+            UserPermission.user_id == target_user_id,
+            UserPermission.module == module,
+            UserPermission.column_key == column_key,
+        )
+        .first()
+    )
+    if record is None:
+        record = UserPermission(user_id=target_user_id, module=module, column_key=column_key)
+        db.add(record)
+    record.can_view = can_view
+    record.can_write = can_write
+    record.updated_by = updated_by
+    record.updated_at = datetime.utcnow()
+
+
+def _can_view_module(db: Session, user: User, module: str) -> bool:
+    if user.role == "admin":
+        return True
+    permissions = _get_user_permissions_payload(db, user)
+    return bool(permissions.get("modules", {}).get(module, {}).get("can_view", True))
+
+
+def _can_write_columns(db: Session, user: User, module: str, fields: list[str]) -> bool:
+    if user.role == "admin":
+        return True
+    if user.role not in ["write", "admin"]:
+        return False
+    permissions = _get_user_permissions_payload(db, user)
+    module_payload = permissions.get("modules", {}).get(module, {})
+    if not module_payload.get("can_view", True):
+        return False
+    column_permissions = module_payload.get("columns", {})
+    return all(bool(column_permissions.get(field, False)) for field in fields)
+
+
+def _ensure_module_view(db: Session, user: User, module: str):
+    if not _can_view_module(db, user, module):
+        raise HTTPException(status_code=403, detail="Module access denied")
+
+
+def _ensure_column_write(db: Session, user: User, module: str, fields: list[str]):
+    if not _can_write_columns(db, user, module, fields):
+        raise HTTPException(status_code=403, detail="Insufficient column permissions")
+
 # ============ ENDPOINTS DE AUTENTICACIÓN ============
 
 @app.post("/login", response_model=Token)
@@ -461,6 +618,67 @@ async def delete_user(
     return {"message": "User deleted"}
 
 
+@app.get("/permissions/me")
+async def get_my_permissions(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return _get_user_permissions_payload(db, current_user)
+
+
+@app.get("/users/{user_id}/permissions")
+async def get_user_permissions(
+    user_id: int,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin_user),
+):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return _get_user_permissions_payload(db, user)
+
+
+@app.put("/users/{user_id}/permissions")
+async def update_user_permissions(
+    user_id: int,
+    permissions_update: UserPermissionsUpdate,
+    db: Session = Depends(get_db),
+    current_admin: User = Depends(get_current_admin_user),
+):
+    user = db.query(User).filter(User.id == user_id).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    for module, module_update in permissions_update.modules.items():
+        if module not in PERMISSION_MODULES:
+            raise HTTPException(status_code=400, detail=f"Unknown permission module: {module}")
+        _upsert_permission(
+            db,
+            target_user_id=user_id,
+            module=module,
+            column_key="",
+            can_view=bool(module_update.can_view),
+            can_write=False,
+            updated_by=current_admin.id,
+        )
+        valid_columns = PERMISSION_MODULES[module]
+        for column_key, can_write in module_update.columns.items():
+            if column_key not in valid_columns:
+                raise HTTPException(status_code=400, detail=f"Unknown permission column: {module}.{column_key}")
+            _upsert_permission(
+                db,
+                target_user_id=user_id,
+                module=module,
+                column_key=column_key,
+                can_view=False,
+                can_write=bool(can_write),
+                updated_by=current_admin.id,
+            )
+
+    db.commit()
+    return _get_user_permissions_payload(db, user)
+
+
 def _get_or_create_fedex_settings(db: Session) -> AppConnectionSettings:
     settings = (
         db.query(AppConnectionSettings)
@@ -582,6 +800,7 @@ async def get_fedex_tracking(
 
 @app.get("/shipments", response_model=List[ShipmentResponse])
 async def get_shipments(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    _ensure_module_view(db, current_user, "shipping_schedule")
     started_at = time.perf_counter()
     shipments = db.query(Shipment).all()
     elapsed_ms = (time.perf_counter() - started_at) * 1000
@@ -606,6 +825,7 @@ async def get_shipment_by_id(
     current_user: User = Depends(get_current_user)
 ):
     """Obtener un shipment específico por ID"""
+    _ensure_module_view(db, current_user, "shipping_schedule")
     shipment = db.query(Shipment).filter(Shipment.id == shipment_id).first()
     if not shipment:
         raise HTTPException(status_code=404, detail="Shipment not found")
@@ -624,8 +844,7 @@ async def create_shipment(
     current_user: User = Depends(get_current_user)
 ):
     """Crear nuevo shipment con validación robusta y manejo de duplicados"""
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "shipping_schedule", SHIPPING_PERMISSION_COLUMNS)
 
     # Retry para manejar conflictos de concurrencia
     max_retries = 3
@@ -744,9 +963,6 @@ async def update_shipment(
     current_user: User = Depends(get_current_user)
 ):
     """Actualizar shipment con control de concurrencia optimista"""
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
-
     try:
         logger.info(f"Updating shipment {shipment_id}, version {current_version}")
 
@@ -773,6 +989,7 @@ async def update_shipment(
 
         # Aplicar cambios con validación
         update_data = shipment_update.dict(exclude_unset=True)
+        _ensure_column_write(db, current_user, "shipping_schedule", list(update_data.keys()))
         changes_made = {}
 
         for field, new_value in update_data.items():
@@ -869,8 +1086,7 @@ async def delete_shipment(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "shipping_schedule", SHIPPING_PERMISSION_COLUMNS)
     shipment = db.query(Shipment).filter(Shipment.id == shipment_id).first()
     if not shipment:
         raise HTTPException(status_code=404, detail="Shipment not found")
@@ -1026,6 +1242,7 @@ async def get_shipping_logs(
 
 @app.get("/sills", response_model=List[SillResponse])
 async def get_sills(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    _ensure_module_view(db, current_user, "sills")
     return db.query(Sill).order_by(Sill.id.desc()).all()
 
 
@@ -1035,8 +1252,7 @@ async def create_sill(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "sills", SILLS_PERMISSION_COLUMNS)
 
     sill_data = {k: _safe_text(v).strip() for k, v in sill.dict().items()}
     new_sill = Sill(
@@ -1072,14 +1288,13 @@ async def update_sill(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    update_data = sill_update.dict(exclude_unset=True)
+    _ensure_column_write(db, current_user, "sills", list(update_data.keys()))
 
     sill = db.query(Sill).filter(Sill.id == sill_id).first()
     if not sill:
         raise HTTPException(status_code=404, detail="Sill not found")
 
-    update_data = sill_update.dict(exclude_unset=True)
     changes_made = {}
     for field, raw_value in update_data.items():
         new_value = _safe_text(raw_value).strip()
@@ -1111,8 +1326,7 @@ async def delete_sill(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "sills", SILLS_PERMISSION_COLUMNS)
 
     sill = db.query(Sill).filter(Sill.id == sill_id).first()
     if not sill:
@@ -1206,6 +1420,7 @@ def _validate_sill_die_payload(payload: dict) -> dict:
 
 @app.get("/sills/dies", response_model=List[SillDieResponse])
 async def get_sill_dies(db: Session = Depends(get_db), current_user: User = Depends(get_current_user)):
+    _ensure_module_view(db, current_user, "sills_database")
     return db.query(SillDieDatabase).order_by(SillDieDatabase.die_number.asc()).all()
 
 
@@ -1215,8 +1430,7 @@ async def create_sill_die(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "sills_database", [SILLS_DIE_PERMISSION_KEY])
 
     payload = _validate_sill_die_payload(die_data.dict())
     new_die = SillDieDatabase(
@@ -1241,8 +1455,7 @@ async def update_sill_die(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "sills_database", [SILLS_DIE_PERMISSION_KEY])
 
     die = db.query(SillDieDatabase).filter(SillDieDatabase.id == die_id).first()
     if not die:
@@ -1276,8 +1489,7 @@ async def delete_sill_die(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if current_user.role not in ["write", "admin"]:
-        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    _ensure_column_write(db, current_user, "sills_database", [SILLS_DIE_PERMISSION_KEY])
 
     die = db.query(SillDieDatabase).filter(SillDieDatabase.id == die_id).first()
     if not die:

--- a/ShippingServer/migrations/versions/009_add_user_permissions.py
+++ b/ShippingServer/migrations/versions/009_add_user_permissions.py
@@ -1,0 +1,46 @@
+"""Add per-user module and column permissions
+
+Revision ID: 009
+Revises: 008
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+from alembic import op
+
+
+revision = '009'
+down_revision = '008'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_permissions (
+            id SERIAL PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+            module VARCHAR(50) NOT NULL,
+            column_key VARCHAR(100) NOT NULL DEFAULT '',
+            can_view BOOLEAN NOT NULL DEFAULT FALSE,
+            can_write BOOLEAN NOT NULL DEFAULT FALSE,
+            updated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT NOW(),
+            updated_by INTEGER REFERENCES users(id),
+            CONSTRAINT uq_user_permissions_user_module_column UNIQUE (user_id, module, column_key)
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_user_permissions_user_module_column "
+        "ON user_permissions (user_id, module, column_key)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_user_permissions_user_module "
+        "ON user_permissions (user_id, module)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_user_permissions_user_module")
+    op.execute("DROP INDEX IF EXISTS ix_user_permissions_user_module_column")
+    op.execute("DROP TABLE IF EXISTS user_permissions")

--- a/ShippingServer/models.py
+++ b/ShippingServer/models.py
@@ -1,4 +1,4 @@
-﻿# models.py - Estructura de la base de datos
+# models.py - Estructura de la base de datos
 from sqlalchemy import Column, Integer, String, DateTime, Text, ForeignKey, Index, Boolean, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, validates
@@ -333,6 +333,27 @@ class SillDieDatabase(Base):
 
     creator = relationship("User", foreign_keys=[created_by])
     last_modifier = relationship("User", foreign_keys=[last_modified_by])
+
+
+class UserPermission(Base):
+    __tablename__ = "user_permissions"
+
+    __table_args__ = (
+        Index("ix_user_permissions_user_module_column", "user_id", "module", "column_key", unique=True),
+        Index("ix_user_permissions_user_module", "user_id", "module"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    module = Column(String(50), nullable=False)
+    column_key = Column(String(100), nullable=False, default="", server_default=text("''"))
+    can_view = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    can_write = Column(Boolean, nullable=False, default=False, server_default=text("false"))
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    updated_by = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    user = relationship("User", foreign_keys=[user_id])
+    updater = relationship("User", foreign_keys=[updated_by])
 
 
 class AppConnectionSettings(Base):


### PR DESCRIPTION
### Motivation
- Introduce configurable per-user permissions so admins can control module visibility and column-level write access for Shipping Schedule, Sills and the Sills DB.
- Make the UI reflect those permissions (disable/blur modules, disable editing of specific columns and restrict Sills DB actions) and enforce them server-side.

### Description
- Add a new `UserPermission` model and migration `009_add_user_permissions.py` to persist per-user module visibility and per-column write flags. 
- Add server helpers and APIs to compute, read and update permissions (`/permissions/me`, `/users/{id}/permissions` and `PUT /users/{id}/permissions`) and enforce them in endpoints for shipments, sills and sills die database. 
- Add client API methods `get_my_permissions`, `get_user_permissions` and `update_user_permissions` and a new Settings tab `Permissions` that lists users in a dropdown and shows module visibility and per-column "Write" checkboxes (the Sills DB entry is a single general checkbox). 
- Apply permissions in the client main window: modules without view permission are blurred/disabled, shipping columns without write permission are made non-editable and write actions for Sills/Sills DB are gated; Sill edit dialog only enables permitted fields and only sends permitted changes.

### Testing
- Compiled the code with `python -m compileall ShippingServer ShippingClient` and compilation succeeded. 
- Ran unit tests with `PYTHONPATH=ShippingServer pytest -q` and they passed (`9 passed`).
- Verified no whitespace/git-diff issues with `git diff --check` (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05c700cf988331ad887617b290c30f)