### PR TITLE
Debounce websocket shipment reloads

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1005,6 +1005,7 @@ class ModernShippingMainWindow(QMainWindow):
         self._session_expired = False
         self._is_loading_shipments = False
         self._pending_shipment_reload = False
+        self._websocket_reload_timer: Optional[QTimer] = None
         self._table_population_timer: Optional[QTimer] = None
         self._table_population_state: Optional[dict[str, Any]] = None
         self._history_tab_entered_at: Optional[float] = None
@@ -4141,9 +4142,13 @@ class ModernShippingMainWindow(QMainWindow):
                 job_number = data["data"].get("job_number", "")
                 is_own_action = self._is_action_from_current_user(action_by)
 
-                # Solo recargar para actualizaciones realizadas por otros usuarios
+                # Solo recargar para actualizaciones realizadas por otros usuarios.
+                # Los eventos de WebSocket pueden llegar en ráfaga mientras ya hay un
+                # GET /shipments activo. No los metemos en la cola normal porque cada
+                # carga pendiente dispara otra carga al terminar y puede convertirse en
+                # un loop de refresh continuo si el servidor sigue enviando eventos.
                 if msg_type != "shipment_updated" or not is_own_action:
-                    self.load_shipments_async()
+                    self._schedule_websocket_shipment_reload()
 
                 # Notificación discreta solo si la acción la realizó otro usuario
                 if not is_own_action:
@@ -4158,8 +4163,24 @@ class ModernShippingMainWindow(QMainWindow):
             pass
         except Exception as e:
             print(f"Error procesando mensaje WebSocket: {e}")
-    
-    
+
+    def _schedule_websocket_shipment_reload(self):
+        """Debounce shipment reloads requested by WebSocket notifications."""
+        if self._session_expired:
+            return
+        if self._is_loading_shipments:
+            # The in-flight request will return a fresh snapshot. Queuing another
+            # WebSocket-triggered request here can create an endless refresh loop
+            # when update notifications arrive during every load.
+            print("Shipment load already in progress; skipping websocket reload.")
+            return
+
+        if self._websocket_reload_timer is None:
+            self._websocket_reload_timer = QTimer(self)
+            self._websocket_reload_timer.setSingleShot(True)
+            self._websocket_reload_timer.timeout.connect(self.load_shipments_async)
+
+        self._websocket_reload_timer.start(750)
 
     def show_toast(self, message, color="#3B82F6"):
         """Mostrar notificación visual flotante"""


### PR DESCRIPTION
### Motivation
- WebSocket shipment notifications arriving in bursts could trigger repeated calls to `load_shipments_async()` and interact with the existing pending-reload queue to produce an endless refresh loop. 
- The client needs a debounced path for websocket-triggered reloads that coalesces bursts and avoids queuing extra loads while a `GET /shipments` is in flight.

### Description
- Added a dedicated debounce timer `_websocket_reload_timer` and helper method `_schedule_websocket_shipment_reload()` to `ShippingClient/ui/main_window.py` to consolidate WebSocket-triggered reload requests into a single delayed reload. 
- WebSocket handling now routes shipment notifications through `_schedule_websocket_shipment_reload()` instead of calling `load_shipments_async()` directly. 
- If a shipment load is already in progress, websocket-triggered reloads are skipped (logged) rather than queued into the existing pending-reload mechanism to prevent a refresh loop. 
- Changes are contained to `ShippingClient/ui/main_window.py` and committed with the message `Debounce websocket shipment reloads`.

### Testing
- Successfully compiled the modified file with `python -m py_compile ShippingClient/ui/main_window.py` (OK). 
- Ran `git diff --check` to ensure no trailing whitespace or patch issues (OK). 
- Ran `python -m pytest -q` but test collection failed due to missing environment dependencies (`fastapi`, `requests`) in this environment, so full test suite could not be executed (dependencies missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ce04b1a4833184dc55ce4f5228e5)