### PR TITLE
Preserve saved FedEx secret settings

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -700,6 +700,17 @@ def _normalize_fedex_base_url(base_url: str | None) -> str:
     return value.rstrip("/")
 
 
+def _is_masked_fedex_secret(secret_key: str | None) -> bool:
+    return (secret_key or "").strip() == "********"
+
+
+def _has_fedex_secret_for_save(secret_key: str | None, saved_secret_key: str | None) -> bool:
+    incoming_secret = (secret_key or "").strip()
+    if incoming_secret and not _is_masked_fedex_secret(incoming_secret):
+        return True
+    return bool((saved_secret_key or "").strip())
+
+
 @app.get("/settings/connections")
 async def get_connection_settings(
     db: Session = Depends(get_db),
@@ -728,16 +739,17 @@ async def update_fedex_connection_settings(
     base_url = _normalize_fedex_base_url(payload.baseUrl)
     enabled = bool(payload.enabled)
 
-    if enabled and (not api_key or not secret_key):
-        raise HTTPException(status_code=400, detail="FedEx API Key and Secret Key are required when enabled")
     if base_url and not (base_url.startswith("http://") or base_url.startswith("https://")):
         raise HTTPException(status_code=400, detail="FedEx Base URL must start with http:// or https://")
 
     settings = _get_or_create_fedex_settings(db)
+    if enabled and (not api_key or not _has_fedex_secret_for_save(secret_key, settings.secret_key)):
+        raise HTTPException(status_code=400, detail="FedEx API Key and Secret Key are required when enabled")
+
     settings.enabled = enabled
     settings.api_key = api_key
     settings.base_url = base_url
-    if secret_key:
+    if secret_key and not _is_masked_fedex_secret(secret_key):
         settings.secret_key = secret_key
     db.commit()
     db.refresh(settings)

--- a/ShippingServer/tests/test_fedex_service.py
+++ b/ShippingServer/tests/test_fedex_service.py
@@ -88,3 +88,17 @@ def test_fedex_service_uses_override_base_url():
 
     assert token_url == "https://apis-sandbox.fedex.com/oauth/token"
     assert track_url == "https://apis-sandbox.fedex.com/track/v1/trackingnumbers"
+
+
+def test_existing_fedex_secret_allows_blank_secret_on_save():
+    from main import _has_fedex_secret_for_save
+
+    assert _has_fedex_secret_for_save("", "saved-secret") is True
+
+
+def test_masked_fedex_secret_preserves_existing_secret_only():
+    from main import _has_fedex_secret_for_save, _is_masked_fedex_secret
+
+    assert _is_masked_fedex_secret("********") is True
+    assert _has_fedex_secret_for_save("********", "saved-secret") is True
+    assert _has_fedex_secret_for_save("********", "") is False


### PR DESCRIPTION
### Motivation

- Users reported that FedEx credentials appeared lost when saving settings because the backend required a `secretKey` even when the client left the field blank or used the masked placeholder `********`.
- The intent is to allow updating other connection settings without forcing users to re-enter the real FedEx secret if it is already stored and to avoid overwriting the stored secret with the masked placeholder.

### Description

- Added helper functions `def _is_masked_fedex_secret(secret_key: str | None) -> bool` and `def _has_fedex_secret_for_save(secret_key: str | None, saved_secret_key: str | None) -> bool` to centralize placeholder and save logic in `ShippingServer/main.py`.
- Updated `update_fedex_connection_settings` to validate credentials using `_has_fedex_secret_for_save` so an existing stored secret allows saving when the incoming payload leaves the secret blank or masked.
- Prevented overwriting the stored secret when the incoming `secretKey` equals the masked placeholder by only writing `settings.secret_key` when a new non-masked secret is provided.
- Added unit tests in `ShippingServer/tests/test_fedex_service.py` to cover the new behaviors for blank and masked secrets.

### Testing

- Ran `python -m py_compile ShippingServer/main.py ShippingServer/tests/test_fedex_service.py` which completed successfully.
- Ran `cd ShippingServer && PYTHONPATH=. pytest -q` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e2a0cd048331b118d5460dee35c7)