### PR TITLE
Restore local update cell marks

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -3131,7 +3131,10 @@ class ModernShippingMainWindow(QMainWindow):
         if action_id == "refresh":
             return True
         if action_id in {"update_mark", "clear_mark"}:
-            return has_item and role_policy["can_edit"] and module_policy.get("allow_update_mark", True)
+            # Local cell marks are a per-user visual preference stored in QSettings,
+            # not a shipment edit persisted to the database. Keep them available to
+            # users who can view the table, even when they do not have write access.
+            return has_item and module_policy.get("allow_update_mark", True)
         if action_id == "show_mie_trak_address":
             return has_item and module_policy.get("allow_mie_trak_address", False)
         if action_id == "change_status":


### PR DESCRIPTION
### Motivation
- The right-click "Update/Clear Mark" action used to set a local blue highlight on a cell (per-user UI preference) but became unavailable because it was gated by database write permissions, even though it does not modify the DB.

### Description
- Change `can_execute_context_action` so `update_mark`/`clear_mark` require only a selected cell and the module's `allow_update_mark` flag (remove dependence on global write permission) and add a clarifying comment that these marks are stored per-user in `QSettings` and are not persisted to the server.

### Testing
- Ran `python -m py_compile ShippingClient/ui/main_window.py` which succeeded; running `pytest -q` was attempted but collection failed due to missing test environment dependencies (`fastapi` and `requests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e5ab7f508331b5dc83505f9589f9)