### PR TITLE
Add job number/status permission and gate status-change action

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -1186,7 +1186,7 @@ class ModernShippingMainWindow(QMainWindow):
             "modules": {
                 "shipping_schedule": {
                     "can_view": True,
-                    "columns": {key: can_write for key in self.TABLE_COLUMN_KEYS if key != "job_number"},
+                    "columns": {**{key: can_write for key in self.TABLE_COLUMN_KEYS}, "status": can_write},
                 },
                 "sills": {
                     "can_view": True,
@@ -3196,11 +3196,12 @@ class ModernShippingMainWindow(QMainWindow):
                 "can_delete": False,
                 "can_change_status": False,
             }
-        can_write_shipping = self._can_write_all("shipping_schedule", [key for key in self.TABLE_COLUMN_KEYS if key != "job_number"])
+        can_write_shipping = self._can_write_all("shipping_schedule", self.TABLE_COLUMN_KEYS)
+        can_change_status = self._column_can_write("shipping_schedule", "status")
         return {
             "can_edit": can_write_shipping,
             "can_delete": can_write_shipping,
-            "can_change_status": can_write_shipping,
+            "can_change_status": can_change_status,
         }
 
     def _get_module_policy(self, module_id: str) -> dict[str, bool]:
@@ -4055,7 +4056,8 @@ class ModernShippingMainWindow(QMainWindow):
 
     def change_status(self, table, row, new_status):
         """Change shipment status with flexible version control"""
-        if not self._get_role_policy().get("can_change_status", False):
+        if not self._column_can_write("shipping_schedule", "status"):
+            self.show_error("You do not have permission to change the job status.")
             return
 
         job_item = table.item(row, 0)

--- a/ShippingClient/ui/settings_dialog.py
+++ b/ShippingClient/ui/settings_dialog.py
@@ -347,7 +347,9 @@ class SettingsDialog(QDialog):
             module_key="shipping_schedule",
             title="Shipping Schedule",
             rows=[
+                ("job_number", "Job Number"),
                 ("job_name", "Job Name"),
+                ("status", "Job Status"),
                 ("description", "Description"),
                 ("qc_release", "QC Rel."),
                 ("qc_notes", "QC Notes"),

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -21,7 +21,9 @@ from fedex_service import FedExService
 
 
 SHIPPING_PERMISSION_COLUMNS = [
+    "job_number",
     "job_name",
+    "status",
     "description",
     "qc_release",
     "qc_notes",
@@ -115,6 +117,7 @@ class ShipmentCreate(BaseModel):
     address: str = ""
 
 class ShipmentUpdate(BaseModel):
+    job_number: str = None
     job_name: str = None
     week: str = None
     description: str = None


### PR DESCRIPTION
### Motivation
- Allow administrators to grant per-user permission to edit the job number and to change a job's status from the UI context menu so users missing that permission cannot change status by right-click → Status.

### Description
- Add `"job_number"` and `"status"` to `SHIPPING_PERMISSION_COLUMNS` in `ShippingServer/main.py` so the backend recognizes these as permissionable fields.
- Add `job_number` to the `ShipmentUpdate` schema in `ShippingServer/main.py` so the API maps the new permission to an editable field.
- Expose `Job Number` and `Job Status` options in the permissions UI by updating `ShippingClient/ui/settings_dialog.py` permission rows for the `shipping_schedule` module.
- Update client permission payloads and runtime checks in `ShippingClient/ui/main_window.py` to include `status` in default permissions and to gate the right-click → Status menu and inline status changes on `_column_can_write("shipping_schedule", "status")`, showing a clear error when the user lacks the permission.

### Testing
- Ran `python -m compileall ShippingServer ShippingClient` which completed successfully and byte-compiled the modified modules.
- Ran `pytest -q` which aborted during collection due to missing external dependencies in the environment (`fastapi` and `requests`), so automated tests could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05ea53b564833195b2ec69f17e8614)