### PR TITLE
Improve printed table header contrast

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -6085,8 +6085,8 @@ class ModernShippingMainWindow(QMainWindow):
                         ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
 
                         # Header styling
-                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#2563EB")),
-                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.whitesmoke),
+                        ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#E5E7EB")),
+                        ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
                         ("FONTSIZE", (0, 0), (-1, 0), header_font_size),
                         ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
 


### PR DESCRIPTION
### Motivation
- El header de la tabla que se exporta a PDF tenía fondo azul oscuro con texto en blanco, lo que producía bajo contraste con el contenido impreso; se busca un header más neutro y legible.

### Description
- Cambiado el estilo del header en la generación de PDF en `ShippingClient/ui/main_window.py` para usar fondo gris claro `#E5E7EB` y texto negro en lugar del azul `#2563EB` y texto blanco.

### Testing
- Ejecutado `python -m py_compile ShippingClient/ui/main_window.py` y la comprobación de bytecode compiló correctamente (sin errores).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fdfcd4608331a33054aca7181702)