### PR TITLE
Add Sills issue tracking and Mie Trak verification scheduler

### DIFF
--- a/ShippingClient/ui/main_window.py
+++ b/ShippingClient/ui/main_window.py
@@ -2369,10 +2369,10 @@ class ModernShippingMainWindow(QMainWindow):
         actions_layout.addLayout(secondary_actions)
 
         self.sills_table = QTableWidget()
-        self.sills_table.setColumnCount(15)
+        self.sills_table.setColumnCount(16)
         self.sills_table.setHorizontalHeaderLabels([
             "Material", "Dimension", "Location", "Die #", "Type", "Speed", "Width",
-            "Sales Order", "Work Order", "Assembly Number", "Description", "Qty",
+            "Sales Order", "Work Order", "Assembly Number", "Issue", "Description", "Qty",
             "Dimension Needed", "Notes", "Week to Print",
         ])
         self.sills_table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
@@ -2383,8 +2383,8 @@ class ModernShippingMainWindow(QMainWindow):
         sills_header.setDefaultAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
         self.sills_table.setWordWrap(True)
         self.sills_table.setItemDelegateForColumn(9, self.code39_barcode_delegate)  # Assembly Number barcode
-        self.sills_table.setItemDelegateForColumn(10, self.wrap_anywhere_delegate)  # Description
-        self.sills_table.setItemDelegateForColumn(13, self.wrap_anywhere_delegate)  # Notes
+        self.sills_table.setItemDelegateForColumn(11, self.wrap_anywhere_delegate)  # Description
+        self.sills_table.setItemDelegateForColumn(14, self.wrap_anywhere_delegate)  # Notes
         self._apply_table_style(self.sills_table)
         self._configure_table_row_metrics(self.sills_table)
 
@@ -2566,13 +2566,29 @@ class ModernShippingMainWindow(QMainWindow):
         self.sills_table.setRowCount(len(rows))
         field_order = [
             "material", "dimension", "location", "die_number", "type", "speed", "width",
-            "sales_order", "work_order", "assembly_number", "description", "qty",
+            "sales_order", "work_order", "assembly_number", "issue_progress", "description", "qty",
             "dimension_needed", "notes", "week_to_print",
         ]
         for row_index, sill in enumerate(rows):
+            issue_quantity = str(sill.get("issue_quantity") or "0").strip() or "0"
+            issue_required = str(sill.get("issue_quantity_required") or "").strip()
+            issue_progress = f"{issue_quantity}/{issue_required}" if issue_required else issue_quantity
+            row_values = {**sill, "issue_progress": issue_progress}
+            issue_status = str(sill.get("issue_status") or "pending").strip().lower()
+            if issue_status == "complete":
+                row_background = QBrush(QColor("#DCFCE7"))
+            elif issue_status == "partial":
+                row_background = QBrush(QColor("#FEF9C3"))
+            else:
+                row_background = None
             for col_index, field in enumerate(field_order):
-                value = "" if sill.get(field) is None else str(sill.get(field))
-                self.sills_table.setItem(row_index, col_index, QTableWidgetItem(value))
+                value = "" if row_values.get(field) is None else str(row_values.get(field))
+                item = QTableWidgetItem(value)
+                if field == "issue_progress":
+                    item.setToolTip("Issued Quantity / Quantity Required")
+                if row_background is not None:
+                    item.setBackground(row_background)
+                self.sills_table.setItem(row_index, col_index, item)
         self.sills_table.resizeColumnsToContents()
         self.sills_table.resizeRowsToContents()
 
@@ -4435,6 +4451,10 @@ class ModernShippingMainWindow(QMainWindow):
             data = json.loads(message)
             msg_type = data.get("type")
             
+            if msg_type == "sills_issue_status_updated":
+                self.load_sills()
+                return
+
             if msg_type in ["shipment_created", "shipment_updated", "shipment_deleted"]:
                 action_by = data["data"].get("action_by", "User")
                 job_number = data["data"].get("job_number", "")
@@ -5763,13 +5783,14 @@ class ModernShippingMainWindow(QMainWindow):
                 "Job",
                 "WO",
                 "Assembly",
+                "Issue",
                 "Description",
                 "Qty",
                 "Dim",
                 "Notes",
                 "Week",
             ],
-            column_map=list(range(15)),
+            column_map=list(range(16)),
             column_weights=[
                 3,   # Mat (narrow)
                 3,   # Dim (narrow)
@@ -5780,14 +5801,15 @@ class ModernShippingMainWindow(QMainWindow):
                 4,   # Width
                 6,   # Job
                 5,   # WO
-                20,  # Assembly
+                18,  # Assembly
+                5,   # Issue
                 14,  # Description
                 3,   # Qty
                 3,   # Dim (narrow)
-                26,  # Notes (widest)
+                24,  # Notes (widest)
                 6,   # Week
             ],
-            wrap_columns=[10, 13],  # Solo Description y Notes
+            wrap_columns=[11, 14],  # Solo Description y Notes
             page_size=(17, 11),
             min_font_size=12,
             min_title_font_size=18,

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -2,17 +2,19 @@
 from fastapi import FastAPI, Depends, HTTPException, status, WebSocket, WebSocketDisconnect, Query
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
-from typing import List
+from typing import List, Any
 from datetime import timedelta, datetime, date
 import json
 import asyncio
 import logging
 import time
+import importlib
+from decimal import Decimal, InvalidOperation
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm.exc import StaleDataError
 
 # Imports locales
-from database import get_db, create_tables, create_admin_user
+from database import get_db, create_tables, create_admin_user, SessionLocal
 from models import User, Shipment, AuditLog, ShippingLog, AppConnectionSettings, Sill, SillLog, SillDieDatabase, UserPermission
 from auth import authenticate_user, create_access_token, get_current_user, get_current_admin_user, Token, UserLogin, UserCreate
 from pydantic import BaseModel, Field
@@ -275,6 +277,10 @@ class SillResponse(BaseModel):
     sales_order: str
     work_order: str
     assembly_number: str
+    issue_quantity: str = "0"
+    issue_quantity_required: str = ""
+    issue_status: str = "pending"
+    issue_checked_at: datetime | None = None
     description: str
     qty: str
     dimension_needed: str
@@ -1191,6 +1197,7 @@ async def startup_event():
     create_tables()
     print("👤 Configurando usuario admin...")
     create_admin_user()
+    asyncio.create_task(_sills_issue_status_scheduler())
     print("✅ Servidor listo en http://localhost:8000")
     print("📡 WebSocket disponible en ws://localhost:8000/ws")
 
@@ -1268,6 +1275,143 @@ async def get_shipping_logs(
         )
         for log in logs
     ]
+
+
+
+MIE_TRAK_SERVER = "GUNDMAIN"
+MIE_TRAK_DATABASE = "GunderlinLive"
+MIE_TRAK_USER = "mie"
+MIE_TRAK_PASSWORD = "mie"
+ISSUE_COMPLETE_STATUS = "complete"
+ISSUE_PARTIAL_STATUS = "partial"
+ISSUE_PENDING_STATUS = "pending"
+ISSUE_CHECK_INTERVAL_SECONDS = 60 * 60
+
+
+def _decimal_from_value(value: Any) -> Decimal:
+    if value is None or value == "":
+        return Decimal("0")
+    try:
+        return Decimal(str(value).strip())
+    except (InvalidOperation, ValueError):
+        return Decimal("0")
+
+
+def _format_issue_quantity(value: Decimal) -> str:
+    normalized = value.quantize(Decimal("0.001")).normalize()
+    return format(normalized, "f")
+
+
+def _fetch_mie_trak_issue_snapshot(assembly_number: str) -> dict[str, str]:
+    """Return issue quantities for one Mie Trak WorkOrderAssemblyNumber."""
+    pymssql = importlib.import_module("pymssql")
+    cleaned_assembly = str(assembly_number or "").strip()
+    conn = None
+    try:
+        conn = pymssql.connect(
+            server=MIE_TRAK_SERVER,
+            user=MIE_TRAK_USER,
+            password=MIE_TRAK_PASSWORD,
+            database=MIE_TRAK_DATABASE,
+        )
+        cursor = conn.cursor(as_dict=True)
+        cursor.execute(
+            """
+            SELECT TOP 1
+                WorkOrderAssemblyNumber,
+                WorkOrderAssemblyBOMStatusFK,
+                QuantityRequired
+            FROM WorkOrderAssembly
+            WHERE WorkOrderAssemblyNumber = %s
+            """,
+            (cleaned_assembly,),
+        )
+        assembly_row = cursor.fetchone()
+        if not assembly_row:
+            return {
+                "issue_quantity": "0",
+                "issue_quantity_required": "",
+                "issue_status": ISSUE_PENDING_STATUS,
+            }
+
+        required = _decimal_from_value(assembly_row.get("QuantityRequired"))
+        bom_status = str(assembly_row.get("WorkOrderAssemblyBOMStatusFK") or "").strip()
+        issued = Decimal("0")
+        if bom_status == "5":
+            cursor.execute(
+                """
+                SELECT COALESCE(SUM(Quantity), 0) AS QuantityIssued
+                FROM WorkOrderCollection
+                WHERE WorkOrderAssemblyNumber = %s
+                """,
+                (cleaned_assembly,),
+            )
+            collection_row = cursor.fetchone() or {}
+            issued = _decimal_from_value(collection_row.get("QuantityIssued"))
+
+        if required > 0 and issued >= required:
+            status = ISSUE_COMPLETE_STATUS
+        elif issued > 0:
+            status = ISSUE_PARTIAL_STATUS
+        else:
+            status = ISSUE_PENDING_STATUS
+
+        return {
+            "issue_quantity": _format_issue_quantity(issued),
+            "issue_quantity_required": _format_issue_quantity(required) if required else "",
+            "issue_status": status,
+        }
+    finally:
+        if conn:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def _refresh_pending_sills_issue_status(db: Session) -> int:
+    """Refresh all Sills that still need Mie Trak issue verification."""
+    pending_sills = (
+        db.query(Sill)
+        .filter(Sill.assembly_number != "")
+        .filter(Sill.issue_status != ISSUE_COMPLETE_STATUS)
+        .all()
+    )
+    updated_count = 0
+    for sill in pending_sills:
+        snapshot = _fetch_mie_trak_issue_snapshot(sill.assembly_number)
+        now = datetime.utcnow()
+        changed = False
+        for field_name in ("issue_quantity", "issue_quantity_required", "issue_status"):
+            value = snapshot[field_name]
+            if getattr(sill, field_name) != value:
+                setattr(sill, field_name, value)
+                changed = True
+        sill.issue_checked_at = now
+        if changed:
+            sill.updated_at = now
+            updated_count += 1
+    if pending_sills:
+        db.commit()
+    return updated_count
+
+
+async def _sills_issue_status_scheduler():
+    await asyncio.sleep(5)
+    while True:
+        db = SessionLocal()
+        try:
+            updated_count = await asyncio.to_thread(_refresh_pending_sills_issue_status, db)
+            if updated_count:
+                await manager.broadcast(json.dumps({
+                    "type": "sills_issue_status_updated",
+                    "data": {"updated_count": updated_count},
+                }))
+        except Exception as exc:
+            logger.warning(f"Failed to refresh Sills issue status: {exc}")
+        finally:
+            db.close()
+        await asyncio.sleep(ISSUE_CHECK_INTERVAL_SECONDS)
 
 
 # ============ ENDPOINTS DE SILLS ============

--- a/ShippingServer/migrations/versions/010_add_sills_issue_tracking.py
+++ b/ShippingServer/migrations/versions/010_add_sills_issue_tracking.py
@@ -1,0 +1,32 @@
+"""Add Sills issue tracking columns
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-05-14 00:00:00.000000
+
+"""
+from alembic import op
+
+
+revision = '010'
+down_revision = '009'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE sills ADD COLUMN IF NOT EXISTS issue_quantity VARCHAR(30) NOT NULL DEFAULT '0'")
+    op.execute("ALTER TABLE sills ADD COLUMN IF NOT EXISTS issue_quantity_required VARCHAR(30) NOT NULL DEFAULT ''")
+    op.execute("ALTER TABLE sills ADD COLUMN IF NOT EXISTS issue_status VARCHAR(20) NOT NULL DEFAULT 'pending'")
+    op.execute("ALTER TABLE sills ADD COLUMN IF NOT EXISTS issue_checked_at TIMESTAMP WITHOUT TIME ZONE")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sills_assembly_number ON sills (assembly_number)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sills_issue_status ON sills (issue_status)")
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_sills_issue_status")
+    op.execute("DROP INDEX IF EXISTS ix_sills_assembly_number")
+    op.execute("ALTER TABLE sills DROP COLUMN IF EXISTS issue_checked_at")
+    op.execute("ALTER TABLE sills DROP COLUMN IF EXISTS issue_status")
+    op.execute("ALTER TABLE sills DROP COLUMN IF EXISTS issue_quantity_required")
+    op.execute("ALTER TABLE sills DROP COLUMN IF EXISTS issue_quantity")

--- a/ShippingServer/models.py
+++ b/ShippingServer/models.py
@@ -260,6 +260,8 @@ class Sill(Base):
         Index("ix_sills_week_to_print", "week_to_print"),
         Index("ix_sills_sales_order", "sales_order"),
         Index("ix_sills_work_order", "work_order"),
+        Index("ix_sills_assembly_number", "assembly_number"),
+        Index("ix_sills_issue_status", "issue_status"),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -273,6 +275,10 @@ class Sill(Base):
     sales_order = Column(String(30), nullable=False, default="", server_default=text("''"))
     work_order = Column(String(30), nullable=False, default="", server_default=text("''"))
     assembly_number = Column(String(50), nullable=False, default="", server_default=text("''"))
+    issue_quantity = Column(String(30), nullable=False, default="0", server_default=text("'0'"))
+    issue_quantity_required = Column(String(30), nullable=False, default="", server_default=text("''"))
+    issue_status = Column(String(20), nullable=False, default="pending", server_default=text("'pending'"))
+    issue_checked_at = Column(DateTime, nullable=True)
     description = Column(Text, nullable=False, default="", server_default=text("''"))
     qty = Column(String(20), nullable=False, default="", server_default=text("''"))
     dimension_needed = Column(String(30), nullable=False, default="", server_default=text("''"))


### PR DESCRIPTION
### Motivation
- Expose whether a Sill has been issued by checking Mie Trak `WorkOrderAssembly`/`WorkOrderCollection` so the sheet shows issued vs required quantities and line completion state. 
- Provide an automated hourly verification that stops checking lines once they reach the required issued quantity. 
- Surface issue progress in the UI and PDF export and visually highlight complete/partial rows.

### Description
- Add persistent fields to the `Sill` model: `issue_quantity`, `issue_quantity_required`, `issue_status`, and `issue_checked_at`, and add indexes for `assembly_number` and `issue_status` (file: `ShippingServer/models.py`).
- Create migration `010_add_sills_issue_tracking.py` to add the new columns and indexes to the database (file: `ShippingServer/migrations/versions/010_add_sills_issue_tracking.py`).
- Extend the API response model `SillResponse` to include the new issue fields (file: `ShippingServer/main.py`).
- Implement Mie Trak lookup helpers (`_fetch_mie_trak_issue_snapshot`, `_decimal_from_value`, `_format_issue_quantity`) and a refresh loop (`_refresh_pending_sills_issue_status`) that sums `WorkOrderCollection.Quantity` when `WorkOrderAssemblyBOMStatusFK == 5`, determines `pending/partial/complete`, updates DB rows and stops rechecking completed lines (file: `ShippingServer/main.py`).
- Start an async background scheduler `_sills_issue_status_scheduler` at server startup to run the check every hour and broadcast `sills_issue_status_updated` via WebSocket when rows change (file: `ShippingServer/main.py`).
- Add an `Issue` column to the Sills Sheet UI, populate it as `Issued/Required` (or `Issued` when required is empty), color rows green for `complete` and light yellow for `partial`, and update PDF export column map/weights accordingly (file: `ShippingClient/ui/main_window.py`).
- Add client-side WebSocket handling to reload Sills when the server broadcasts `sills_issue_status_updated` (file: `ShippingClient/ui/main_window.py`).

### Testing
- Compiled the codebase with `python -m compileall ShippingServer ShippingClient test_mie_trak_client.py test_api_client.py` and compilation succeeded. 
- Ran the unit test `pytest -q test_mie_trak_client.py` and it passed (`1 passed`).
- Ran full `pytest -q` in this environment which failed during collection due to missing external test dependencies (`fastapi`, `requests`) but not because of the new logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0604bd5cdc833195d8cc480098fdf4)