### PR TITLE
Fix WebSocket root connection spam

### DIFF
--- a/ShippingClient/core/settings_manager.py
+++ b/ShippingClient/core/settings_manager.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, date
 from PyQt6.QtCore import QSettings, Qt
+from .websocket_url import normalize_websocket_url
 
 
 class SettingsManager:
@@ -19,15 +20,10 @@ class SettingsManager:
 
     def get_ws_url(self) -> str:
         """Return stored websocket URL or default."""
-        value = self._settings.value("ws_url", "ws://localhost:8000/ws")
-        cleaned = (value or "ws://localhost:8000/ws").strip().rstrip("/")
-        return cleaned or "ws://localhost:8000/ws"
+        return normalize_websocket_url(self._settings.value("ws_url", "ws://localhost:8000/ws"))
 
     def set_ws_url(self, url: str):
-        cleaned = (url or "").strip()
-        if cleaned.endswith("/"):
-            cleaned = cleaned.rstrip("/")
-        self._settings.setValue("ws_url", cleaned)
+        self._settings.setValue("ws_url", normalize_websocket_url(url))
 
     def get_mie_trak_server(self) -> str:
         """Return configured Mie Trak SQL Server name."""

--- a/ShippingClient/core/websocket_client.py
+++ b/ShippingClient/core/websocket_client.py
@@ -1,7 +1,8 @@
-﻿# core/websocket_client.py - Cliente WebSocket separado
+# core/websocket_client.py - Cliente WebSocket separado
 import websocket
 from PyQt6.QtCore import QThread, pyqtSignal
 from .config import get_ws_url
+from .websocket_url import normalize_websocket_url
 
 class WebSocketClient(QThread):
     message_received = pyqtSignal(str)
@@ -11,8 +12,7 @@ class WebSocketClient(QThread):
         super().__init__()
         self.ws = None
         self.running = False
-        base_url = (url or get_ws_url() or "").strip()
-        self.url = base_url.rstrip("/")
+        self.url = normalize_websocket_url(url or get_ws_url())
     
     def run(self):
         def on_message(ws, message):
@@ -26,7 +26,10 @@ class WebSocketClient(QThread):
             print("WebSocket connection closed")
             self.connection_status.emit(False)
         
+        reconnect_delay = {"seconds": 1}
+
         def on_open(ws):
+            reconnect_delay["seconds"] = 1
             print("WebSocket connection opened")
             self.connection_status.emit(True)
         
@@ -39,18 +42,19 @@ class WebSocketClient(QThread):
         )
         
         self.running = True
-        # run_forever() handles reconnect internally (ping_interval, etc.).
-        # Only retry externally on a fatal crash, with linear backoff.
-        backoff = 1
+        # Reconnect with backoff whenever run_forever returns. A rejected
+        # handshake returns immediately, so sleeping here prevents log spam.
         while self.running:
             try:
                 self.ws.run_forever(ping_interval=30, ping_timeout=10)
             except Exception as e:
                 print(f"WebSocket fatal exception: {e}")
                 self.connection_status.emit(False)
-                if self.running:
-                    self.sleep(min(backoff, 30))
-                    backoff += 2
+
+            if self.running:
+                delay = min(reconnect_delay["seconds"], 30)
+                self.sleep(delay)
+                reconnect_delay["seconds"] = delay + 2
     
     def stop(self):
         self.running = False

--- a/ShippingClient/core/websocket_url.py
+++ b/ShippingClient/core/websocket_url.py
@@ -1,0 +1,37 @@
+"""Utilities for normalizing Shipping Schedule WebSocket URLs."""
+from urllib.parse import urlsplit, urlunsplit
+
+DEFAULT_WEBSOCKET_PATH = "/ws"
+DEFAULT_WEBSOCKET_URL = "ws://localhost:8000/ws"
+
+
+def normalize_websocket_url(url: str | None, default: str = DEFAULT_WEBSOCKET_URL) -> str:
+    """Return a usable WebSocket URL, defaulting root paths to ``/ws``.
+
+    Users sometimes enter the server root (for example ``ws://host:8000`` or
+    ``http://host:8000``) in the WebSocket setting. FastAPI only serves the
+    realtime endpoint at ``/ws``, so root WebSocket attempts are rejected with
+    repeated 403 log entries. This helper keeps custom non-root paths intact
+    while converting an empty/root path to the app's default WebSocket path.
+    """
+    raw_url = str(url or "").strip() or default
+
+    if raw_url.startswith("//"):
+        raw_url = f"ws:{raw_url}"
+    elif "://" not in raw_url:
+        raw_url = f"ws://{raw_url}"
+
+    parsed = urlsplit(raw_url)
+    scheme = parsed.scheme.lower()
+    if scheme == "http":
+        scheme = "ws"
+    elif scheme == "https":
+        scheme = "wss"
+    elif scheme not in {"ws", "wss"}:
+        scheme = "ws"
+
+    path = parsed.path.rstrip("/")
+    if not path:
+        path = DEFAULT_WEBSOCKET_PATH
+
+    return urlunsplit((scheme, parsed.netloc, path, parsed.query, parsed.fragment))

--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -1179,9 +1179,7 @@ async def delete_shipment(
 
 # ============ WEBSOCKET ============
 
-@app.websocket("/ws")
-@app.websocket("/ws/")
-async def websocket_endpoint(websocket: WebSocket):
+async def _handle_websocket_connection(websocket: WebSocket):
     await manager.connect(websocket)
     try:
         while True:
@@ -1189,6 +1187,21 @@ async def websocket_endpoint(websocket: WebSocket):
             await websocket.receive_text()
     except WebSocketDisconnect:
         manager.disconnect(websocket)
+
+
+@app.websocket("/ws")
+@app.websocket("/ws/")
+async def websocket_endpoint(websocket: WebSocket):
+    await _handle_websocket_connection(websocket)
+
+
+@app.websocket("/")
+async def websocket_root_compat_endpoint(websocket: WebSocket):
+    logger.warning(
+        "WebSocket client connected to root path; accepting for compatibility. "
+        "Update clients to use /ws."
+    )
+    await _handle_websocket_connection(websocket)
 
 # ============ STARTUP ============
 

--- a/test_websocket_url.py
+++ b/test_websocket_url.py
@@ -1,0 +1,17 @@
+from ShippingClient.core.websocket_url import normalize_websocket_url
+
+
+def test_websocket_url_adds_default_path_for_root_urls():
+    assert normalize_websocket_url("ws://10.0.0.77:8000") == "ws://10.0.0.77:8000/ws"
+    assert normalize_websocket_url("ws://10.0.0.77:8000/") == "ws://10.0.0.77:8000/ws"
+
+
+def test_websocket_url_accepts_server_url_inputs():
+    assert normalize_websocket_url("http://server.example:8000") == "ws://server.example:8000/ws"
+    assert normalize_websocket_url("https://server.example") == "wss://server.example/ws"
+    assert normalize_websocket_url("server.example:8000") == "ws://server.example:8000/ws"
+
+
+def test_websocket_url_preserves_custom_non_root_paths():
+    assert normalize_websocket_url("wss://server.example/realtime/") == "wss://server.example/realtime"
+    assert normalize_websocket_url("ws://server.example/ws?token=abc") == "ws://server.example/ws?token=abc"


### PR DESCRIPTION
### Motivation
- Misconfigured clients that point WebSocket settings at the server root (e.g. `ws://host:8000`, `http://host:8000` or `host:8000`) were triggering repeated 403 rejections and log spam. 
- The desktop client retried connections in a tight loop when the WebSocket handshake was rejected, amplifying the logs. 
- We need a safe normalization of user-provided WS URLs and a small server-side compatibility shim to stop noisy errors while users update their settings.

### Description
- Added `ShippingClient/core/websocket_url.py` with `normalize_websocket_url()` to canonicalize inputs, convert `http(s)` to `ws(s)`, and default root paths to `/ws`.
- Updated `ShippingClient/core/settings_manager.py` to call `normalize_websocket_url()` when reading and persisting the `ws_url` setting so stored values are normalized.
- Updated `ShippingClient/core/websocket_client.py` to use the normalized URL and to implement a reconnect backoff when `run_forever()` returns so rejected handshakes do not loop rapidly and flood logs.
- Updated `ShippingServer/main.py` to accept WebSocket connections on `/` for compatibility, emit a `logger.warning` advising clients to switch to `/ws`, and delegate handling to a shared connection coroutine.
- Added `test_websocket_url.py` unit tests covering root URLs, HTTP(S) inputs, and preserving custom non-root paths.

### Testing
- Ran `python -m pytest test_websocket_url.py` and all tests passed (3 passed). 
- Verified syntax by running `python -m py_compile ShippingClient/core/websocket_url.py ShippingClient/core/websocket_client.py ShippingClient/core/settings_manager.py ShippingServer/main.py` which succeeded. 
- Ran full `python -m pytest` in this environment but test collection failed due to missing external dependencies (`fastapi`, `requests`), so the failure is environment-related rather than due to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0617222b548331a7d3932ddba107e4)