### PR TITLE
Fix Sills issue-status query to use WorkOrderAssemblyPK and correct issued-quantity logic

### DIFF
--- a/ShippingServer/main.py
+++ b/ShippingServer/main.py
@@ -1318,7 +1318,7 @@ def _format_issue_quantity(value: Decimal) -> str:
 
 
 def _fetch_mie_trak_issue_snapshot(assembly_number: str) -> dict[str, str]:
-    """Return issue quantities for one Mie Trak WorkOrderAssemblyNumber."""
+    """Return issue quantities for one Mie Trak WorkOrderAssemblyPK."""
     pymssql = importlib.import_module("pymssql")
     cleaned_assembly = str(assembly_number or "").strip()
     conn = None
@@ -1332,12 +1332,13 @@ def _fetch_mie_trak_issue_snapshot(assembly_number: str) -> dict[str, str]:
         cursor = conn.cursor(as_dict=True)
         cursor.execute(
             """
-            SELECT TOP 1
-                WorkOrderAssemblyNumber,
-                WorkOrderAssemblyBOMStatusFK,
-                QuantityRequired
-            FROM WorkOrderAssembly
-            WHERE WorkOrderAssemblyNumber = %s
+            SELECT
+                woa.WorkOrderAssemblyPK AS assemblyNumber,
+                woa.WorkOrderAssemblyBOMStatusFK AS bomStatusFk,
+                COALESCE(woa.QuantityRequired, 0) AS quantityRequired,
+                COALESCE(woa.QuantityIssued, 0) AS issuedQuantity
+            FROM dbo.WorkOrderAssembly woa
+            WHERE woa.WorkOrderAssemblyPK = %s;
             """,
             (cleaned_assembly,),
         )
@@ -1349,28 +1350,15 @@ def _fetch_mie_trak_issue_snapshot(assembly_number: str) -> dict[str, str]:
                 "issue_status": ISSUE_PENDING_STATUS,
             }
 
-        required = _decimal_from_value(assembly_row.get("QuantityRequired"))
-        bom_status = str(assembly_row.get("WorkOrderAssemblyBOMStatusFK") or "").strip()
-        cursor.execute(
-            """
-            SELECT COALESCE(SUM(Quantity), 0) AS QuantityIssued
-            FROM WorkOrderCollection
-            WHERE WorkOrderAssemblyNumber = %s
-            """,
-            (cleaned_assembly,),
-        )
-        collection_row = cursor.fetchone() or {}
-        issued = _decimal_from_value(collection_row.get("QuantityIssued"))
+        required = _decimal_from_value(assembly_row.get("quantityRequired"))
+        issued = _decimal_from_value(assembly_row.get("issuedQuantity"))
 
-        if bom_status == "5" and issued <= 0 and required > 0:
-            issued = required
-
-        if required > 0 and issued >= required:
-            status = ISSUE_COMPLETE_STATUS
-        elif issued > 0:
+        if issued <= 0:
+            status = ISSUE_PENDING_STATUS
+        elif issued < required:
             status = ISSUE_PARTIAL_STATUS
         else:
-            status = ISSUE_PENDING_STATUS
+            status = ISSUE_COMPLETE_STATUS
 
         return {
             "issue_quantity": _format_issue_quantity(issued),


### PR DESCRIPTION
### Motivation
- The Mie Trak query was referencing a non-existent `WorkOrderAssemblyNumber` column on `dbo.WorkOrderAssembly`, causing failures when refreshing Sills issue-status.
- The issued-quantity logic relied on BOM status gating and a separate `WorkOrderCollection` sum, which produced incorrect or missing issued totals.

### Description
- Updated `_fetch_mie_trak_issue_snapshot` to query `dbo.WorkOrderAssembly` by `woa.WorkOrderAssemblyPK` using positional `%s` parameters for `pymssql` and to select `COALESCE(woa.QuantityRequired, 0) AS quantityRequired` and `COALESCE(woa.QuantityIssued, 0) AS issuedQuantity` directly from the assembly row.
- Removed the secondary `WorkOrderCollection` SUM/lookup and the BOM-status special-case, so issued quantity is always taken from `WorkOrderAssembly.QuantityIssued` when available.
- Simplified status determination to always calculate `issue_status` from `issuedQuantity` vs `quantityRequired` with rules: `pending` if `issued = 0`, `partial` if `0 < issued < required`, and `complete` if `issued >= required`.
- Kept connection handling and formatting helpers intact and ensured the query uses a positional parameter tuple `(cleaned_assembly,)`.

### Testing
- Ran `python -m py_compile ShippingServer/main.py` and it completed successfully.
- Ran `pytest -q`, which failed during collection due to missing environment dependencies (`ModuleNotFoundError: No module named 'fastapi'` and `ModuleNotFoundError: No module named 'requests'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0619c3ba9c8331b825759ac9fc8ed0)